### PR TITLE
Fix engine gimbal for RD-8, NK33 and NK43

### DIFF
--- a/GameData/ROEngines/PartConfigs/NK33_RE.cfg
+++ b/GameData/ROEngines/PartConfigs/NK33_RE.cfg
@@ -72,6 +72,7 @@ PART
 		dependOnThrottle = True
 	}
 	
+	MODULE
 	{
 	    name = ModuleGimbal
 	    gimbalTransformName = gimbal

--- a/GameData/ROEngines/PartConfigs/NK43_RE.cfg
+++ b/GameData/ROEngines/PartConfigs/NK43_RE.cfg
@@ -71,6 +71,7 @@ PART
 		dependOnThrottle = True
 	}
 	
+	MODULE
 	{
 	    name = ModuleGimbal
 	    gimbalTransformName = gimbal

--- a/GameData/ROEngines/PartConfigs/RD8_RE.cfg
+++ b/GameData/ROEngines/PartConfigs/RD8_RE.cfg
@@ -64,6 +64,7 @@ PART
 		dependOnThrottle = True
 	}
 	
+	MODULE
 	{
 	    name = ModuleGimbal
 	    gimbalTransformName = gimbal


### PR DESCRIPTION
Fixes Issue #19 , MODULE line missing over ModuleGimbal blocks.