### PR TITLE
Biprop Plumes and offsets for niche parts

### DIFF
--- a/GameData/ROEngines/RealPlume/AJ10-190_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/AJ10-190_SSTU_RealPlume.cfg
@@ -2,7 +2,7 @@
 {
     PLUME
     {
-        name = Hypergolic-OMSd
+        name = Hypergolic-OMS-Red
         transformName = AJ10-190-ThrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,1.0
@@ -12,6 +12,6 @@
     }
 	@MODULE[ModuleEngines*]
 	{
-        %powerEffectName = Hypergolic-OMSd
+        %powerEffectName = Hypergolic-OMS-Red
 	}
 }

--- a/GameData/ROEngines/RealPlume/MR104_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/MR104_NicheParts_RealPlume.cfg
@@ -19,7 +19,7 @@
 		transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.525
         flareScale =    0.2
-        plumePosition = 0.0, 0.0, -0.625
+        plumePosition = 0.0, 0.0, 0.525
         plumeScale =    0.2
         fixedScale =	0.2
 		energy = 		1.0

--- a/GameData/ROEngines/RealPlume/MR104_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/MR104_NicheParts_RealPlume.cfg
@@ -15,7 +15,7 @@
     }
 	PLUME
     {
-        name = Hypergolic-OMSd
+        name = Hypergolic-OMS-Red
 		transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.625
         flareScale =    0.2
@@ -39,27 +39,27 @@
 
         @CONFIG[MMH+NTO]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
 
         @CONFIG[MMH+MON3]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
 
         @CONFIG[UDMH+NTO]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
 
         @CONFIG[Aerozine50+NTO]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
 
         @CONFIG[Cavea-B]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
     }
 }

--- a/GameData/ROEngines/RealPlume/MR104_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/MR104_NicheParts_RealPlume.cfg
@@ -6,7 +6,7 @@
 		transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.625
         flareScale =    0.2
-        plumePosition = 0.0, 0.0, -0.625
+        plumePosition = 0.0, 0.0, 0.0
         plumeScale =    0.2
         fixedScale =	0.2
 		energy = 		1.0
@@ -17,7 +17,7 @@
     {
         name = Hypergolic-OMS-Red
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, -0.625
+        flarePosition = 0.0, 0.0, 0.525
         flareScale =    0.2
         plumePosition = 0.0, 0.0, -0.625
         plumeScale =    0.2

--- a/GameData/ROEngines/RealPlume/PLE_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/PLE_NicheParts_RealPlume.cfg
@@ -19,7 +19,7 @@
 		transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.5
         flareScale =    0.08
-        plumePosition = 0.0, 0.0, 0.0
+        plumePosition = 0.0, 0.0, 0.5
         plumeScale =    0.08
         fixedScale =	0.08
 		energy = 		1.0

--- a/GameData/ROEngines/RealPlume/PLE_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/PLE_NicheParts_RealPlume.cfg
@@ -17,7 +17,7 @@
     {
         name = Hypergolic-OMS-Red
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, -0.77
+        flarePosition = 0.0, 0.0, 0.5
         flareScale =    0.08
         plumePosition = 0.0, 0.0, 0.0
         plumeScale =    0.08

--- a/GameData/ROEngines/RealPlume/PLE_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/PLE_NicheParts_RealPlume.cfg
@@ -15,7 +15,7 @@
     }
 	PLUME
     {
-        name = Hypergolic-OMSd
+        name = Hypergolic-OMS-Red
 		transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.77
         flareScale =    0.08
@@ -39,27 +39,27 @@
 
         @CONFIG[MMH+NTO]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
 
         @CONFIG[MMH+MON3]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
 
         @CONFIG[UDMH+NTO]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
 
         @CONFIG[Aerozine50+NTO]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
 
         @CONFIG[Cavea-B]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
     }
 }

--- a/GameData/ROEngines/RealPlume/S400_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/S400_NicheParts_RealPlume.cfg
@@ -15,7 +15,7 @@
     }
 	PLUME
     {
-        name = Hypergolic-OMSd
+        name = Hypergolic-OMS-Red
 		transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.45
         flareScale =    0.5		
@@ -39,27 +39,27 @@
 
         @CONFIG[MMH+NTO]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
 
         @CONFIG[MMH+MON3]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
 
         @CONFIG[UDMH+NTO]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
 
         @CONFIG[Aerozine50+NTO]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
 
         @CONFIG[Cavea-B]
         {
-            %powerEffectName = Hypergolic-OMSd
+            %powerEffectName = Hypergolic-OMS-Red
         }
     }
 }

--- a/GameData/ROEngines/RealPlume/S400_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/S400_NicheParts_RealPlume.cfg
@@ -4,9 +4,9 @@
     {
         name = Hypergolic-OMS-White
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.45
+        flarePosition = 0.0, 0.0, -.4
         flareScale =    0.5		
-        plumePosition = 0.0, 0.0, 0.45
+        plumePosition = 0.0, 0.0, 0.15
         plumeScale =    0.5
         fixedScale =	0.5
 		energy = 		1.0


### PR DESCRIPTION
#23 - Discussion and demonstration on the RealPlume issues with these parts which are both solved by this pull request (at least in my install). 

Some confusion was had because monoprop engines use both flares and plumes while biprop configs only do plumes (that look like flares). The real kicker is that the different plume types all need different offsets, ooh boy.