### PR TITLE
Upgrade RS-25 and RS-68 with new plumes, fix RS-68 vernier/turbopump …

### DIFF
--- a/GameData/ROEngines/RealPlume/RS25_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RS25_SSTU_RealPlume.cfg
@@ -3,17 +3,24 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesFX
-		%powerEffectName = Hydrolox-Lower
+		%powerEffectName = Cryogenic_LowerSSME_CE
     }
     PLUME
     {
-        name = Hydrolox-Lower
+        name = Cryogenic_LowerSSME_CE
         transformName = RS-25-ThrustTransform
         localRotation = 0,0,0
-		plumePosition = 0,0,2.5
-        plumeScale = 3.0
-		flarePosition = 0,0,2.25
-		flareScale = 2.8
+		shockPosition = 0,0,2.4
+		shockScale = 0.87
+
+		plumePosition = 0,0,2.1
+		plumeScale = 2.6
+
+		plume2Scale = 1.3
+		
+		corePosition = 0,0,0
+		coreScale = 1
+		
         energy = 1.0
         speed = 1
     }

--- a/GameData/ROEngines/RealPlume/RS68_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RS68_SSTU_RealPlume.cfg
@@ -2,11 +2,19 @@
 {
     PLUME
     {
-        name = Hydrolox-Lower
+        name = Cryogenic_LowerAblative_CE
         transformName = RS-68-MainFXTransform
         localRotation = 0,0,0
         localPosition = 0,0,2.3
-        plumePosition = 0, 0, 2.4
+		
+		flarePosition = 0,0,1.3
+		fixedScale = 1.1
+		
+		corePosition = 0,0,2.3
+		coreScale = 1.45
+		
+        plumePosition = 0, 0, 2.3
+		plumeScale = 1.45
         fixedScale = 3
         energy = 1
         speed = 1
@@ -16,18 +24,32 @@
         name = Hydrolox-Upper
         transformName = RS-68-RollExhaust
         localRotation = 0, 0, 0
-        flarePosition = 0,0.015,0.43
-		plumePosition = 0,0,0.63
-        fixedScale = 0.33
+        flarePosition = 0,0.015,0.71
+		plumePosition = 0,0,1.1
+        fixedScale = 0.3
         energy = 1
         speed = 0.5
     }
+}
+
+@PART[ROE-RS68]:AFTER[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
+{
+	@EFFECTS
+	{
+		@CombinedPlume:HAS[#plumeIdentifier[Hydrolox-Upper]]
+		{
+			@MODEL_MULTI_SHURIKEN_PERSIST:HAS[#name[Hydrolox-Upper-plume_grey]]
+			{
+				@localPosition = 0,0,0.23
+			}
+		}
+	}
 }
 @PART[ROE-RS68]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
 {
     @EFFECTS
     {
-        @Hydrolox-Lower
+        @Cryogenic_LowerAblative_CE
         {
             |_ = CombinedPlume
         }


### PR DESCRIPTION
…exhaust. Requires newest RealPlume version.

- RS-68 Sea Level : ![screenshot67](https://user-images.githubusercontent.com/39596827/66008512-20166f00-e4b7-11e9-9c3b-2fc04cc74b99.png)
- RS-68 Vacuum : ![screenshot70](https://user-images.githubusercontent.com/39596827/66008523-2dcbf480-e4b7-11e9-9ae0-dcdb328fb751.png)

- RS-25 Sea Level : ![screenshot74](https://user-images.githubusercontent.com/39596827/66008550-44724b80-e4b7-11e9-97b1-a66f57bbd7b1.png) ![screenshot71](https://user-images.githubusercontent.com/39596827/66008559-4f2ce080-e4b7-11e9-891c-dc064044d45c.png)

- RS-25 Vacuum : 
![screenshot72](https://user-images.githubusercontent.com/39596827/66008577-679cfb00-e4b7-11e9-9717-72056a78b7b1.png)
![screenshot73](https://user-images.githubusercontent.com/39596827/66008582-6a97eb80-e4b7-11e9-9d68-5c82ff13596c.png)

