### PR TITLE
Add XLR43

### DIFF
--- a/GameData/ROEngines/PartConfigs/XLR43.cfg
+++ b/GameData/ROEngines/PartConfigs/XLR43.cfg
@@ -1,0 +1,125 @@
+PART
+{
+	module = Part
+	name = ROE-XLR43
+	author = Alcentar, Pap, capkirk123
+	
+	category = Engine
+	subcategory = 0
+	RSSROConfig = true
+	RP0conf = true
+	
+	crashTolerance = 10
+	maxTemp = 673.15
+	skinTemp = 773.15
+	fuelCrossfeed = true
+	breakingForce = 10000
+	breakingTorque = 10000
+	
+	//  ============================================================================
+	//	Update Below
+	//  ============================================================================
+	
+	MODEL
+	{
+		// Dimensions: 4.03 x 1.7
+		model = ROEngines/Assets/RealEngines/A7
+		scale = 0.75, 0.75, 0.75
+	}
+	MODEL
+    {
+        model = RealismOverhaul/emptyengine
+        position = 0.285, -1.39, 0.0
+        rotation = 0.0, 0.0, 0.0
+    }
+    MODEL
+    {
+        model = RealismOverhaul/emptyengine
+        position = -0.285, -1.39, 0.0
+        rotation = 0.0, 0.0, 0.0
+    }
+    MODEL
+    {
+        model = RealismOverhaul/emptyengine
+        position = 0.0, -1.39, 0.285
+        rotation = 0.0, 0.0, 0.0
+    }
+    MODEL
+    {
+        model = RealismOverhaul/emptyengine
+        position = 0.0, -1.39, -0.285
+        rotation = 0.0, 0.0, 0.0
+    }
+	
+	scale = 1.0
+	rescaleFactor = 1.0
+	node_stack_top = 0,1.195,0,0,1,0,2
+	node_stack_bottom = 0,-1.23,0,0,-1,0,2
+	node_attach = 0,1.195,0,0,1,0,2
+	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+	attachRules = 1,1,1,0,0	
+	
+	title = XLR43 Series
+	manufacturer = North American Aviation (NAA)
+	description = Predecessor of all American liquid fueled boosters. Started as an upgraded copy of the German A-4. Rocketdyne engineers were able to solve the combustion instability issues of the A-4, allowing significant improvements. This became the XLR43-NA-1, which evolved into the Redstone NAA 75-110. Further improvements were added in the XLR43-NA-3, which evolved into the Navaho XLR71 booster, and when modified to burn kerosene, the Atlas LR43 engines. Diameter: 1.77 m.
+	
+	tags = navaho
+	
+	engineType = XLR43
+	stagingIcon = LIQUID_ENGINE
+	
+	TechRequired = earlyRocketry
+	cost = 300
+	entryCost = 16000
+	stageOffset = 1
+    childStageOffset = 1
+	
+	//FX
+	fx_exhaustFlame_blue_small = 0.0, -0.8, 0.0, 0.0, 1.0, 0.0, running
+	fx_exhaustLight_blue = 0.0, -0.8, 0.0, 0.0, 0.0, 1.0, running
+	fx_smokeTrail_light = 0.0, -1.3, 0.0, 0.0, 1.0, 0.0, running
+	sound_vent_medium = engage
+	sound_rocket_hard = running
+	sound_vent_soft = disengage
+	sound_explosion_low = flameout
+	
+	MODULE
+	{
+		name = ModuleEnginesRF
+		thrustVectorTransformName = newThrustTransform
+	}
+	
+	MODULE
+	{
+		name = ModuleGimbal
+		gimbalTransformName = newThrustTransform
+		gimbalRange = 2.0
+		useGimbalResponseSpeed = true
+		gimbalResponseSpeed = 16
+	}
+	
+	{
+	name = FXModuleLookAtConstraint
+	CONSTRAINLOOKFX
+	{
+		targetName = t
+		rotatorsName = 1
+	}
+
+	CONSTRAINLOOKFX
+	{
+		targetName = 1
+		rotatorsName = t
+	}
+	
+	MODULE
+	{
+		name = ModuleSurfaceFX
+		thrustProviderModuleIndex = 0
+		fxMax = 0.5
+		maxDistance = 30
+		falloff = 1.7
+		thrustTransformName = thrustTransform
+	}
+	
+}

--- a/GameData/ROEngines/PartConfigs/XLR43.cfg
+++ b/GameData/ROEngines/PartConfigs/XLR43.cfg
@@ -70,7 +70,7 @@ PART
 	
 	TechRequired = earlyRocketry
 	cost = 300
-	entryCost = 16000
+	entryCost = 0
 	stageOffset = 1
     childStageOffset = 1
 	

--- a/GameData/ROEngines/RealPlume/XLR43_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/XLR43_RE_RealPlume.cfg
@@ -1,0 +1,52 @@
+//  ==================================================
+//  NAA XLR43 Series engine plume setup.
+//  ==================================================
+
+@PART[ROE-XLR43]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Alcolox-Lower-A6
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, -0.075
+        plumeScale = 0.4
+        flarePosition = 0.0, 0.0, 0.975
+        flareScale = 0.45
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 0.75
+        speed = 1.0
+        emissionMult = 0.75
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Alcolox-Lower-A6
+        !runningEffectName = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Alcolox-Lower-A6
+        }
+    }
+}
+
+//  ==================================================
+//  NAA XLR43 Series engine plume configuration.
+//  ==================================================
+
+@PART[ROE-XLR43]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Alcolox-Lower-A6
+        }
+    }
+}


### PR DESCRIPTION
Add XLR43, using NAA-75-110 model due to extreme similarity.

RP-1 ECM & Tree configs: https://github.com/KSP-RO/RP-0/pull/1158
RO Engine Configs: https://github.com/KSP-RO/RealismOverhaul/pull/2164
See for sources and further information