### PR TITLE
Update for LF2 Agena

### DIFF
--- a/GameData/ROEngines/PartConfigs/Agena_SSTU.cfg
+++ b/GameData/ROEngines/PartConfigs/Agena_SSTU.cfg
@@ -137,6 +137,7 @@ PART
 		!CONFIG[Model8096-39] {}
 		!CONFIG[Model8096A] {}
 		!CONFIG[Model8096L] {}
+		!CONFIG[XLR81-LF2-SPS] {}
 	}
 }
 

--- a/GameData/ROEngines/RealPlume/Agena_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Agena_SSTU_RealPlume.cfg
@@ -83,6 +83,41 @@
         energy = 1
         speed = 1
     }
+	PLUME
+    {
+        name = Cryogenic_UpperBlue_CE
+        transformName = LR-81-8096-ThrustTransform
+		emissionMult = 1
+        energy = 2.5
+        speed = 1
+		alphaMult = 1
+
+		plumePosition = 0,0,0.7
+		plumeScale = 0.5
+		plume2Scale = 1
+		
+		corePosition = 0,0,0.65
+		coreScale = 1.0
+    }
+	PLUME
+    {
+		name = Cryogenic_LowerRed_CE
+		transformName = LR-81-8096-ExhaustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,0
+
+		speed = 1
+		energy = 1
+		emissionMult = 1
+
+		corePosition = 0,0,0
+		coreScale = 0.0
+
+		plumePosition = 0,0,0.0
+		plumeScale = 0.1
+
+		plume2Scale = 0.1
+    }
 }
 @PART[ROE-Agena8096]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
 {
@@ -90,16 +125,36 @@
     {
         @Hypergolic-OMS-White
         {
-            |_ = CombinedPlume
+            |_ = CombinedPlumeHypergolic
         }
         @Hypergolic-Vernier
         {
-            |_ = CombinedPlume
+            |_ = CombinedPlumeHypergolic
+        }
+		@Cryogenic_UpperBlue_CE
+		{
+            |_ = CombinedPlumeHydrolox
+        }
+		@Cryogenic_LowerRed_CE
+		{
+            |_ = CombinedPlumeHydrolox
         }
     }
-    @MODULE[ModuleEnginesRF]
+	@MODULE[ModuleEnginesRF]
     {
         %powerEffectName = CombinedPlume
         !runningEffectName = DELETE
+    }
+	@MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*
+        {
+            %powerEffectName = CombinedPlumeHypergolic
+        }
+		@CONFIG[XLR81-LF2-SPS]
+		{
+			%powerEffectName = CombinedPlumeHydrolox
+		}
     }
 }


### PR DESCRIPTION
Prevent LF2 Agena config from being selected on short nozzle agena, and add hydrolox plumes when LF2 Agena is selected.