### PR TITLE
Plume upgrades and fixes

### DIFF
--- a/GameData/ROEngines/RealPlume/A4_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/A4_RE_RealPlume.cfg
@@ -10,8 +10,8 @@
         transformName = thrustTransform
         plumePosition = 0.0, 0.0, 0.0
         plumeScale = 0.35
-        flarePosition = 0.0, 0.0, 0.8
-        flareScale = 0.425
+        flarePosition = 0.0, 0.0, 0.5
+        flareScale = 0.35
         smokePosition = 0.0, 0.0, 0.0
         smokeScale = 1.0
         localRotation = 0.0, 0.0, 0.0

--- a/GameData/ROEngines/RealPlume/A7_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/A7_RE_RealPlume.cfg
@@ -10,8 +10,8 @@
         transformName = thrustTransform
         plumePosition = 0.0, 0.0, -0.075
         plumeScale = 0.4
-        flarePosition = 0.0, 0.0, 0.975
-        flareScale = 0.45
+        flarePosition = 0.0, 0.0, 0.4
+        flareScale = 0.4
         smokePosition = 0.0, 0.0, 0.0
         smokeScale = 1.0
         localRotation = 0.0, 0.0, 0.0
@@ -25,9 +25,9 @@
     {
         name = Hydynelox-A7
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, -1.4
+        plumePosition = 0.0, 0.0, -0.8
         plumeScale = 0.45
-        flarePosition = 0.0, 0.0, 0.25
+        flarePosition = 0.0, 0.0, -0.3
         flareScale = 0.55
         smokePosition = 0.0, 0.0, 0.0
         smokeScale = 1.0

--- a/GameData/ROEngines/RealPlume/AJ10-137_DECQ_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/AJ10-137_DECQ_RealPlume.cfg
@@ -5,15 +5,15 @@
         name = Hypergolic-Apollo-SM
         transformName = thrustTransform
         localRotation = 0,0,0
-		plumePosition = 0,0,-0.5
+        plumePosition = 0,0,-0.5
         plumeScale = 0.8
-		flarePosition = 0,0,-1
-		flareScale = 1
+        flarePosition = 0,0,-1
+        flareScale = 1
         energy = 1.5
         speed = 1.1
     }
-	@MODULE[ModuleEngines*]
-	{
+    @MODULE[ModuleEngines*]
+    {
         %powerEffectName = Hypergolic-Apollo-SM
-	}
+    }
 }

--- a/GameData/ROEngines/RealPlume/AJ10-137_DECQ_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/AJ10-137_DECQ_RealPlume.cfg
@@ -5,10 +5,10 @@
         name = Hypergolic-Apollo-SM
         transformName = thrustTransform
         localRotation = 0,0,0
-		plumePosition = 0,0,0
-        plumeScale = 1.5
-		flarePosition = 0,0,0
-		flareScale = 1.4
+		plumePosition = 0,0,-0.5
+        plumeScale = 0.8
+		flarePosition = 0,0,-1
+		flareScale = 1
         energy = 1.5
         speed = 1.1
     }

--- a/GameData/ROEngines/RealPlume/AJ10-190_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/AJ10-190_SSTU_RealPlume.cfg
@@ -1,33 +1,24 @@
 @PART[ROE-AJ10-190]:NEEDS[RealPlume]:BEFORE[RealPlume]
 {
-    PLUME
+    PLUME_TEMPLATE
     {
-        name = Hypergolic-Apollo-SM
+        name = Hypergolic_UpperWhite
         transformName = AJ10-190-ThrustTransform
-        plumePosition = 0.0, 0.0, -0.8
-        plumeScale = 0.45
-        flarePosition = 0.0, 0.0, -1.2
-        flareScale = 0.425
-        smokePosition = 0.0, 0.0, 0.0
-        smokeScale = 1.0
-        localRotation = 0.0, 0.0, 0.0
-        fixedScale = 1.0
-        energy = 1.0
-        speed = 1.0
-        emissionMult = 0.5
+        scale = 0.5
+		offset = 0.7
     }
 
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Hypergolic-Apollo-SM
-        !runningEffectName = DELETE
-    }
-
-    @MODULE[ModuleEngineConfigs]
-    {
-        @CONFIG,*
-        {
-            %powerEffectName = Hypergolic-Apollo-SM
-        }
-    }
+    //@MODULE[ModuleEngines*]
+    //{
+    //    %powerEffectName = Hypergolic-Apollo-SM
+    //    !runningEffectName = DELETE
+    //}
+	//
+    //@MODULE[ModuleEngineConfigs]
+    //{
+    //    @CONFIG,*
+    //    {
+    //        %powerEffectName = Hypergolic-Apollo-SM
+    //    }
+    //}
 }

--- a/GameData/ROEngines/RealPlume/AJ10-190_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/AJ10-190_SSTU_RealPlume.cfg
@@ -2,16 +2,32 @@
 {
     PLUME
     {
-        name = Hypergolic-OMS-Red
+        name = Hypergolic-Apollo-SM
         transformName = AJ10-190-ThrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,1.0
-        fixedScale = 1.7
-        energy = 1.5
-        speed = 1
+        plumePosition = 0.0, 0.0, -0.8
+        plumeScale = 0.45
+        flarePosition = 0.0, 0.0, -1.2
+        flareScale = 0.425
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Hypergolic-OMS-Red
-	}
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-Apollo-SM
+        !runningEffectName = DELETE
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-Apollo-SM
+        }
+    }
 }

--- a/GameData/ROEngines/RealPlume/AJ10-190_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/AJ10-190_SSTU_RealPlume.cfg
@@ -5,20 +5,6 @@
         name = Hypergolic_UpperWhite
         transformName = AJ10-190-ThrustTransform
         scale = 0.5
-		offset = 0.7
+        offset = 0.7
     }
-
-    //@MODULE[ModuleEngines*]
-    //{
-    //    %powerEffectName = Hypergolic-Apollo-SM
-    //    !runningEffectName = DELETE
-    //}
-	//
-    //@MODULE[ModuleEngineConfigs]
-    //{
-    //    @CONFIG,*
-    //    {
-    //        %powerEffectName = Hypergolic-Apollo-SM
-    //    }
-    //}
 }

--- a/GameData/ROEngines/RealPlume/AJ10Adv_MCD_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/AJ10Adv_MCD_RealPlume.cfg
@@ -23,10 +23,10 @@
         name = Hydrolox-Upper
         transformName = thrustTransform
         localRotation = 0,0,0
-		plumePosition = 0,0,2.7
-        plumeScale = 1.3
-        flarePosition = 0,0,2.6
-        flareScale = 1.35
+		plumePosition = 0,0,3.5
+        plumeScale = 1.1
+        flarePosition = 0,0,2.1
+        flareScale = 1.1
         energy = 1
         speed = 1
     }
@@ -34,10 +34,10 @@
     {
         name = Hypergolic-Upper
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 2.7
+        plumePosition = 0.0, 0.0, 2.6
         plumeScale = 1.3
-        flarePosition = 0.0, 0.0, 2.6
-        flareScale = 1.35
+        flarePosition = 0.0, 0.0, 2.05
+        flareScale = 1.19
         smokePosition = 0.0, 0.0, 0.0
         smokeScale = 1.0
         localRotation = 0.0, 0.0, 0.0

--- a/GameData/ROEngines/RealPlume/AJ10Adv_MCD_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/AJ10Adv_MCD_RealPlume.cfg
@@ -1,10 +1,10 @@
 @PART[ROE-AJ10Adv]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		!runningEffectName = DELETE
-	}
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        !runningEffectName = DELETE
+    }
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
@@ -12,25 +12,25 @@
         {
             %powerEffectName = Hypergolic-Upper
         }
-		@CONFIG[AJ10-133-LH]
-		{
-			%powerEffectName = Hydrolox-Upper
-		}
+        @CONFIG[AJ10-133-LH]
+        {
+            %powerEffectName = Hydrolox-Upper
+        }
     }
     
-	PLUME
+    PLUME
     {
         name = Hydrolox-Upper
         transformName = thrustTransform
         localRotation = 0,0,0
-		plumePosition = 0,0,3.5
+        plumePosition = 0,0,3.5
         plumeScale = 1.1
         flarePosition = 0,0,2.1
         flareScale = 1.1
         energy = 1
         speed = 1
     }
-	PLUME
+    PLUME
     {
         name = Hypergolic-Upper
         transformName = thrustTransform

--- a/GameData/ROEngines/RealPlume/AJ260_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/AJ260_BDB_RealPlume.cfg
@@ -1,15 +1,15 @@
 @PART[ROE-AJ260SLA]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		!runningEffectName = DELETE
-		!fxOffset = DELETE
-		%powerEffectName = Solid-Lower
-	}
-	@MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleEngines*]
     {
-		%type = ModuleEnginesRF
+        @name = ModuleEnginesRF
+        !runningEffectName = DELETE
+        !fxOffset = DELETE
+        %powerEffectName = Solid-Lower
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
     }
     PLUME
     {
@@ -26,9 +26,9 @@
 
 @PART[ROE-AJ260SLF]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleEngineConfigs]
     {
-		%type = ModuleEnginesRF
+        %type = ModuleEnginesRF
     }
     PLUME
     {
@@ -41,7 +41,7 @@
         energy = 1
         speed = 1
     }
-	PLUME
+    PLUME
     {
         name = Solid-Sepmotor
         transformName = vernierTransform
@@ -74,16 +74,16 @@
 
 @PART[ROE-AJ260FLA]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		!runningEffectName = DELETE
-		!fxOffset = DELETE
-		%powerEffectName = Solid-Lower
-	}
-	@MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleEngines*]
     {
-		%type = ModuleEnginesRF
+        @name = ModuleEnginesRF
+        !runningEffectName = DELETE
+        !fxOffset = DELETE
+        %powerEffectName = Solid-Lower
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
     }
     PLUME
     {
@@ -100,9 +100,9 @@
 
 @PART[ROE-AJ260FLF]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleEngineConfigs]
     {
-		%type = ModuleEnginesRF
+        %type = ModuleEnginesRF
     }
     PLUME
     {
@@ -115,7 +115,7 @@
         energy = 1
         speed = 1
     }
-	PLUME
+    PLUME
     {
         name = Solid-Sepmotor
         transformName = vernierTransform

--- a/GameData/ROEngines/RealPlume/Aerobee_Taerobee_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Aerobee_Taerobee_RealPlume.cfg
@@ -11,8 +11,9 @@
         transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,0
-        plumePosition = 0,0,0.1
-        flarePosition = 0,0,0.44
+        plumePosition = 0,0,0.15
+        flarePosition = 0,0,0.38
+		flareScale = 0.18
         fixedScale = 0.25
         energy = 1
         speed = 1

--- a/GameData/ROEngines/RealPlume/Aerobee_Taerobee_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Aerobee_Taerobee_RealPlume.cfg
@@ -1,10 +1,10 @@
 @PART[ROE-Aerobee]:NEEDS[RealPlume,SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesFX
-		%powerEffectName = Hypergolic-Lower
-	}
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesFX
+        %powerEffectName = Hypergolic-Lower
+    }
     PLUME
     {
         name = Hypergolic-Lower
@@ -13,7 +13,7 @@
         localPosition = 0,0,0
         plumePosition = 0,0,0.15
         flarePosition = 0,0,0.38
-		flareScale = 0.18
+        flareScale = 0.18
         fixedScale = 0.25
         energy = 1
         speed = 1

--- a/GameData/ROEngines/RealPlume/Agena_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Agena_SSTU_RealPlume.cfg
@@ -9,12 +9,12 @@
         name = Hypergolic-OMS-White
         transformName = LR-81-8048-ThrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.1
-        fixedScale = 0.4
+        localPosition = 0,0,0.4
+        fixedScale = 0.7
         energy = 1.2
         speed = 1.5
-        flarePosition = 0.0, 0.0, 0.3
-        flareScale = 0.5
+        flarePosition = 0.0, 0.0, -0.4
+        flareScale = 0.28
         // flare emissionMult = 0.2
     }
     PLUME
@@ -22,8 +22,8 @@
         name = Hypergolic-Vernier
         transformName = LR-81-8048-ExhaustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.65
-        fixedScale = 1
+        localPosition = 0,0,1.0
+        fixedScale = 0.35
         energy = 1
         speed = 1
     }
@@ -65,12 +65,12 @@
         name = Hypergolic-OMS-White
         transformName = LR-81-8096-ThrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.5
-        fixedScale = 0.6
+        localPosition = 0,0,0.71
+        fixedScale = 0.8
         energy = 1.2
         speed = 1.5
-        flarePosition = 0.0, 0.0, 0.75
-        flareScale = 0.75
+        flarePosition = 0.0, 0.0, -0.1
+        flareScale = 0.37
         // flare emissionMult = 0.2
     }
     PLUME
@@ -78,8 +78,8 @@
         name = Hypergolic-Vernier
         transformName = LR-81-8096-ExhaustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.6
-        fixedScale = 1
+        localPosition = 0,0,1.0
+        fixedScale = 0.35
         energy = 1
         speed = 1
     }

--- a/GameData/ROEngines/RealPlume/Agena_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Agena_SSTU_RealPlume.cfg
@@ -1,6 +1,6 @@
-//	==================================================
-//	XLR81 Agena plume configuration.
-//	==================================================
+//  ==================================================
+//  XLR81 Agena plume configuration.
+//  ==================================================
 // Copied/adapted from VSR file
 @PART[ROE-Agena8048]:NEEDS[RealPlume]:BEFORE[RealPlume]
 {
@@ -49,16 +49,16 @@
 }
 
 
-//	==================================================
-//	XLR81 Agena plume configuration.(large nozzle)
-//	==================================================
+//  ==================================================
+//  XLR81 Agena plume configuration.(large nozzle)
+//  ==================================================
 // Copied/adapted from VSR file
 
 @PART[ROE-Agena8096]:NEEDS[RealPlume]:BEFORE[RealPlume]
 {
-	@MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleEngineConfigs]
     {
-		%type = ModuleEnginesRF
+        %type = ModuleEnginesRF
     }
     PLUME
     {
@@ -83,40 +83,40 @@
         energy = 1
         speed = 1
     }
-	PLUME
+    PLUME
     {
         name = Cryogenic_UpperBlue_CE
         transformName = LR-81-8096-ThrustTransform
-		emissionMult = 1
+        emissionMult = 1
         energy = 2.5
         speed = 1
-		alphaMult = 1
+        alphaMult = 1
 
-		plumePosition = 0,0,0.7
-		plumeScale = 0.5
-		plume2Scale = 1
-		
-		corePosition = 0,0,0.65
-		coreScale = 1.0
+        plumePosition = 0,0,0.7
+        plumeScale = 0.5
+        plume2Scale = 1
+        
+        corePosition = 0,0,0.65
+        coreScale = 1.0
     }
-	PLUME
+    PLUME
     {
-		name = Cryogenic_LowerRed_CE
-		transformName = LR-81-8096-ExhaustTransform
-		localRotation = 0,0,0
-		localPosition = 0,0,0
+        name = Cryogenic_LowerRed_CE
+        transformName = LR-81-8096-ExhaustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0
 
-		speed = 1
-		energy = 1
-		emissionMult = 1
+        speed = 1
+        energy = 1
+        emissionMult = 1
 
-		corePosition = 0,0,0
-		coreScale = 0.0
+        corePosition = 0,0,0
+        coreScale = 0.0
 
-		plumePosition = 0,0,0.0
-		plumeScale = 0.1
+        plumePosition = 0,0,0.0
+        plumeScale = 0.1
 
-		plume2Scale = 0.1
+        plume2Scale = 0.1
     }
 }
 @PART[ROE-Agena8096]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
@@ -131,30 +131,30 @@
         {
             |_ = CombinedPlumeHypergolic
         }
-		@Cryogenic_UpperBlue_CE
-		{
+        @Cryogenic_UpperBlue_CE
+        {
             |_ = CombinedPlumeHydrolox
         }
-		@Cryogenic_LowerRed_CE
-		{
+        @Cryogenic_LowerRed_CE
+        {
             |_ = CombinedPlumeHydrolox
         }
     }
-	@MODULE[ModuleEnginesRF]
+    @MODULE[ModuleEnginesRF]
     {
         %powerEffectName = CombinedPlume
         !runningEffectName = DELETE
     }
-	@MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = CombinedPlumeHypergolic
         }
-		@CONFIG[XLR81-LF2-SPS]
-		{
-			%powerEffectName = CombinedPlumeHydrolox
-		}
+        @CONFIG[XLR81-LF2-SPS]
+        {
+            %powerEffectName = CombinedPlumeHydrolox
+        }
     }
 }

--- a/GameData/ROEngines/RealPlume/AltairIII_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/AltairIII_RN_RealPlume.cfg
@@ -2,28 +2,28 @@
 {
     PLUME
     {
-		name = Solid-Vacuum
+        name = Solid-Vacuum
         transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.38
         flareScale =    0.4
         plumePosition = 0.0, 0.0, 0.5
         plumeScale =    0.7
         //smokePosition = 0.0, 0.0, 0.5
-		//smokeScale = 	0.2
-		energy = 1.0
+        //smokeScale =  0.2
+        energy = 1.0
         speed = 1.0
         emissionMult = 0.5
     }
-	
+    
     @MODULE[ModuleEngines*]
     {
         @name = ModuleEnginesRF
     }
-	
+    
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-        @CONFIG,*   					//Add the effect to every engine config
+        @CONFIG,*                       //Add the effect to every engine config
         {
             %powerEffectName = Solid-Vacuum
         }

--- a/GameData/ROEngines/RealPlume/AltairII_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/AltairII_RN_RealPlume.cfg
@@ -2,28 +2,28 @@
 {
     PLUME
     {
-		name = Solid-Vacuum
+        name = Solid-Vacuum
         transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.38
         flareScale =    0.4
         plumePosition = 0.0, 0.0, 0.5
         plumeScale =    0.7
         //smokePosition = 0.0, 0.0, 0.5
-		//smokeScale = 	0.2
-		energy = 1.0
+        //smokeScale =  0.2
+        energy = 1.0
         speed = 1.0
         emissionMult = 0.5
     }
-	
+    
     @MODULE[ModuleEngines*]
     {
         @name = ModuleEnginesRF
     }
-	
+    
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-        @CONFIG,*   					//Add the effect to every engine config
+        @CONFIG,*                       //Add the effect to every engine config
         {
             %powerEffectName = Solid-Vacuum
         }

--- a/GameData/ROEngines/RealPlume/Altair_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Altair_RN_RealPlume.cfg
@@ -2,28 +2,28 @@
 {
     PLUME
     {
-		name = Solid-Vacuum
+        name = Solid-Vacuum
         transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.38
         flareScale =    0.4
         plumePosition = 0.0, 0.0, 0.5
         plumeScale =    0.7
         //smokePosition = 0.0, 0.0, 0.5
-		//smokeScale = 	0.2
-		energy = 1.0
+        //smokeScale =  0.2
+        energy = 1.0
         speed = 1.0
         emissionMult = 0.5
     }
-	
+    
     @MODULE[ModuleEngines*]
     {
         @name = ModuleEnginesRF
     }
-	
+    
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-        @CONFIG,*   					//Add the effect to every engine config
+        @CONFIG,*                       //Add the effect to every engine config
         {
             %powerEffectName = Solid-Vacuum
         }

--- a/GameData/ROEngines/RealPlume/BE3_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/BE3_NicheParts_RealPlume.cfg
@@ -18,9 +18,9 @@
     {
         name = Hydrolox-Upper
 		transformName = newThrustTransform
-        flarePosition = 0.0, 0.0, 0.75
-        flareScale =    0.3
-        plumePosition = 0.0, 0.0, 0.8
+        flarePosition = 0.03, 0.0, 0.73
+        flareScale =    0.25
+        plumePosition = 0.03, 0.0, 1.1
         plumeScale =    0.3
         fixedScale =	0.3
 		energy = 		1.0

--- a/GameData/ROEngines/RealPlume/BE3_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/BE3_NicheParts_RealPlume.cfg
@@ -3,26 +3,26 @@
     PLUME
     {
         name = Hydrolox-Lower
-		transformName = thrustTransform
+        transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.7
         flareScale =    1.22
-		flareEnergy =	5.0
+        flareEnergy =   5.0
         plumePosition = 0.0, 0.0, 0.7
         plumeScale =    1.1
-        fixedScale =	1.0
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        fixedScale =    1.0
+        energy =        1.0
+        speed =         1.0
+        emissionMult =  1.0
     }
-	PLUME
+    PLUME
     {
         name = Cryogenic_VernierOrange
-		transformName = newThrustTransform
+        transformName = newThrustTransform
         plumePosition = 0.03, 0.0, -0.1
         plumeScale =    1.3
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        energy =        1.0
+        speed =         1.0
+        emissionMult =  1.0
     }
 }
 @PART[ROE-BE3]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]

--- a/GameData/ROEngines/RealPlume/BE3_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/BE3_NicheParts_RealPlume.cfg
@@ -16,13 +16,10 @@
     }
 	PLUME
     {
-        name = Hydrolox-Upper
+        name = Cryogenic_VernierOrange
 		transformName = newThrustTransform
-        flarePosition = 0.03, 0.0, 0.73
-        flareScale =    0.25
-        plumePosition = 0.03, 0.0, 1.1
-        plumeScale =    0.3
-        fixedScale =	0.3
+        plumePosition = 0.03, 0.0, -0.1
+        plumeScale =    1.3
 		energy = 		1.0
         speed = 		1.0
         emissionMult = 	1.0
@@ -36,7 +33,7 @@
         {
             |_ = CombinedPlume
         }
-        @Hydrolox-Upper
+        @Cryogenic_VernierOrange
         {
             |_ = CombinedPlume
         }

--- a/GameData/ROEngines/RealPlume/BabySergeant_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/BabySergeant_RN_RealPlume.cfg
@@ -12,9 +12,9 @@
         flareScale =    0.15
         plumePosition = 0.0, 0.0, 0.06
         plumeScale =    0.075
-		slagScale = 	0.05
+        slagScale =     0.05
         //fixedScale = 1.0
-		energy = 1.0
+        energy = 1.0
         speed = 1.0
         emissionMult = 0.5
     }
@@ -29,7 +29,7 @@
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-		@CONFIG,*
+        @CONFIG,*
         {
             %powerEffectName = Solid-Upper
         }
@@ -46,9 +46,9 @@
         flareScale =    0.5
         plumePosition = 0.0, 0.0, 0.15
         plumeScale =    0.25
-		slagScale = 	0.1
+        slagScale =     0.1
         //fixedScale = 1.0
-		energy = 1.0
+        energy = 1.0
         speed = 1.0
         emissionMult = 0.5
     }
@@ -63,7 +63,7 @@
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-		@CONFIG,*
+        @CONFIG,*
         {
             %powerEffectName = Solid-Upper
         }
@@ -80,9 +80,9 @@
         flareScale =    1.0
         plumePosition = 0.0, 0.0, 0.2
         plumeScale =    0.5
-		slagScale =		0.2
+        slagScale =     0.2
         //fixedScale = 1.0
-		energy = 1.0
+        energy = 1.0
         speed = 1.0
         emissionMult = 0.5
     }
@@ -97,7 +97,7 @@
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-		@CONFIG,*
+        @CONFIG,*
         {
             %powerEffectName = Solid-Upper
         }

--- a/GameData/ROEngines/RealPlume/Castor1_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Castor1_RN_RealPlume.cfg
@@ -1,29 +1,29 @@
 @PART[ROE-Castor1]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-        @CONFIG,*   					//Add the effect to every engine config
+        @CONFIG,*                       //Add the effect to every engine config
         {
             %powerEffectName = Solid-Lower
         }
     }
-	
+    
     PLUME
     {
-		name = Solid-Lower
+        name = Solid-Lower
         transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.0006
         flareScale =    0.6
         plumePosition = 0.0, 0.0, 0.25
         plumeScale =    0.6
         smokePosition = 0.0, 0.0, 0.25
-		smokeScale = 	0.1
-		slagPosition = 	0.0, 0.0, 0.004
-		energy = 1.0
+        smokeScale =    0.1
+        slagPosition =  0.0, 0.0, 0.004
+        energy = 1.0
         speed = 1.0
         emissionMult = 1.5
     }
-	
+    
     
 }

--- a/GameData/ROEngines/RealPlume/Castor2_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Castor2_RN_RealPlume.cfg
@@ -2,29 +2,29 @@
 {
     PLUME
     {
-		name = Solid-Lower
+        name = Solid-Lower
         transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.0006
         flareScale =    0.6
         plumePosition = 0.0, 0.0, 0.004
         plumeScale =    0.6
         smokePosition = 0.0, 0.0, 0.004
-		smokeScale = 	0.1
-		slagPosition = 	0.0, 0.0, 0.004
-		energy = 1.0
+        smokeScale =    0.1
+        slagPosition =  0.0, 0.0, 0.004
+        energy = 1.0
         speed = 1.0
         emissionMult = 1.5
     }
-	
+    
     @MODULE[ModuleEngines*]
     {
         @name = ModuleEnginesRF
     }
-	
+    
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-        @CONFIG,*   					//Add the effect to every engine config
+        @CONFIG,*                       //Add the effect to every engine config
         {
             %powerEffectName = Solid-Lower
         }

--- a/GameData/ROEngines/RealPlume/E1_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/E1_BDB_RealPlume.cfg
@@ -1,27 +1,20 @@
 @PART[ROE-E1]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    @MODULE[ModuleEngineConfigs],*
-    {
-		%type = ModuleEnginesRF
-        @CONFIG,*
-        {
-            %powerEffectName = Kerolox-Lower
-        }
-    }
+    //@MODULE[ModuleEngineConfigs],*
+    //{
+	//	%type = ModuleEnginesRF
+    //    @CONFIG,*
+    //    {
+    //        %powerEffectName = Kerolox-Lower
+    //    }
+    //}
 	
-	PLUME
+	PLUME_TEMPLATE
     {
-        name = Kerolox-Lower
+        name = Kerolox_LowerFlame
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.1
-        flareScale =    1.2
-		flareEnergy =	5.0
-        plumePosition = 0.0, 0.0, 0.35
-        plumeScale =    0.85
-        fixedScale =	1.0
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	0.5
+        scale = 1
+		offset = 0.08
     }
 }
 

--- a/GameData/ROEngines/RealPlume/E1_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/E1_BDB_RealPlume.cfg
@@ -1,20 +1,11 @@
 @PART[ROE-E1]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    //@MODULE[ModuleEngineConfigs],*
-    //{
-	//	%type = ModuleEnginesRF
-    //    @CONFIG,*
-    //    {
-    //        %powerEffectName = Kerolox-Lower
-    //    }
-    //}
-	
-	PLUME_TEMPLATE
+    PLUME_TEMPLATE
     {
         name = Kerolox_LowerFlame
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 1
-		offset = 0.08
+        offset = 0.08
     }
 }
 

--- a/GameData/ROEngines/RealPlume/E1_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/E1_BDB_RealPlume.cfg
@@ -14,10 +14,10 @@
         name = Kerolox-Lower
 		transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.1
-        flareScale =    1.22
+        flareScale =    1.2
 		flareEnergy =	5.0
-        plumePosition = 0.0, 0.0, 0.17
-        plumeScale =    1.1
+        plumePosition = 0.0, 0.0, 0.35
+        plumeScale =    0.85
         fixedScale =	1.0
 		energy = 		1.0
         speed = 		1.0

--- a/GameData/ROEngines/RealPlume/F1_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/F1_SSTU_RealPlume.cfg
@@ -10,10 +10,10 @@
         name = Kerolox-Lower-F1
         transformName = F1-ThrustTransform
 		localRotation = 0,0,0
-		plumePosition = 0,0,3.5
-        plumeScale = 1.5
-		flarePosition = 0,0,3.35
-		flareScale = 1.2
+		plumePosition = 0,0,3
+        plumeScale = 1
+		flarePosition = 0,0,2.4
+		flareScale = 0.87
         energy = 0.7
         speed = 1
     }

--- a/GameData/ROEngines/RealPlume/F1_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/F1_SSTU_RealPlume.cfg
@@ -1,15 +1,10 @@
 @PART[ROE-F1]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	//@MODULE[ModuleEngines*]
-	//{
-	//	@name = ModuleEnginesFX
-	//	%powerEffectName = Kerolox-Lower-F1
-    //}
     PLUME_TEMPLATE
     {
         name = Kerolox_LowerFlame
         transformName = F1-ThrustTransform
-		scale = 2.17
-		offset = 1.7
+        scale = 2.17
+        offset = 1.7
     }
 }

--- a/GameData/ROEngines/RealPlume/F1_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/F1_SSTU_RealPlume.cfg
@@ -1,20 +1,15 @@
 @PART[ROE-F1]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesFX
-		%powerEffectName = Kerolox-Lower-F1
-    }
-    PLUME
+	//@MODULE[ModuleEngines*]
+	//{
+	//	@name = ModuleEnginesFX
+	//	%powerEffectName = Kerolox-Lower-F1
+    //}
+    PLUME_TEMPLATE
     {
-        name = Kerolox-Lower-F1
+        name = Kerolox_LowerFlame
         transformName = F1-ThrustTransform
-		localRotation = 0,0,0
-		plumePosition = 0,0,3
-        plumeScale = 1
-		flarePosition = 0,0,2.4
-		flareScale = 0.87
-        energy = 0.7
-        speed = 1
+		scale = 2.17
+		offset = 1.7
     }
 }

--- a/GameData/ROEngines/RealPlume/GCRC_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/GCRC_RN_RealPlume.cfg
@@ -2,28 +2,28 @@
 {
     PLUME
     {
-		name = Solid-Vacuum
+        name = Solid-Vacuum
         transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.5
         flareScale =    1.0
         plumePosition = 0.0, 0.0, 0.5
         plumeScale =    1.0
         //smokePosition = 0.0, 0.0, 0.5
-		//smokeScale = 	0.2
-		energy = 1.0
+        //smokeScale =  0.2
+        energy = 1.0
         speed = 1.0
         emissionMult = 0.5
     }
-	
+    
     @MODULE[ModuleEngines*]
     {
         @name = ModuleEnginesRF
     }
-	
+    
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-        @CONFIG,*   					//Add the effect to every engine config
+        @CONFIG,*                       //Add the effect to every engine config
         {
             %powerEffectName = Solid-Vacuum
         }

--- a/GameData/ROEngines/RealPlume/H1_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/H1_SSTU_RealPlume.cfg
@@ -6,8 +6,8 @@
         transformName = H-1-ThrustTransform
         localRotation = 0,0,0 
         plumePosition = 0,0,1
-		plumeScale = 0.7
-		flarePosition = 0,0,0.8
+		plumeScale = 0.6
+		flarePosition = 0,0,0.85
         flareScale = 0.9
         energy = 1
         speed = 1		
@@ -34,8 +34,8 @@
         transformName = H-1-ThrustTransform
         localRotation = 0,0,0 
         plumePosition = 0,0,1
-		plumeScale = 0.7
-		flarePosition = 0,0,0.8
+		plumeScale = 0.6
+		flarePosition = 0,0,0.85
         flareScale = 0.9
         energy = 1
         speed = 1		

--- a/GameData/ROEngines/RealPlume/H1_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/H1_SSTU_RealPlume.cfg
@@ -2,7 +2,7 @@
 {
 	PLUME_TEMPLATE
 	{
-		name = Cryogenic_UpperBlue_CE
+		name = Kerolox_LowerAlt
 		transformName = H-1-ThrustTransform
 		scale = 0.71
 		offset = 0.8
@@ -25,7 +25,7 @@
 {
 	PLUME_TEMPLATE
 	{
-		name = Hydrolox_UpperBlue
+		name = Kerolox_LowerFlame
 		transformName = H-1-ThrustTransform
 		scale = 0.71
 		offset = 0.8

--- a/GameData/ROEngines/RealPlume/H1_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/H1_SSTU_RealPlume.cfg
@@ -1,17 +1,12 @@
 @PART[ROE-H1C]:NEEDS[RealPlume]:BEFORE[RealPlume]
 {
-    PLUME
-    {
-        name = Kerolox-Lower
-        transformName = H-1-ThrustTransform
-        localRotation = 0,0,0 
-        plumePosition = 0,0,1
-		plumeScale = 0.6
-		flarePosition = 0,0,0.85
-        flareScale = 0.9
-        energy = 1
-        speed = 1		
-    }
+	PLUME_TEMPLATE
+	{
+		name = Kerolox_LowerAlt
+		transformName = H-1-ThrustTransform
+		scale = 0.71
+		offset = 0.8
+	}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
@@ -21,25 +16,20 @@
 		%type = ModuleEnginesRF
         @CONFIG,*
 		{
-			%powerEffectName = Kerolox-Lower
+			%powerEffectName = Kerolox_LowerAlt
 		}
 	}
 }
 
 @PART[ROE-H1D]:NEEDS[RealPlume]:BEFORE[RealPlume]
 {
-    PLUME
-    {
-        name = Kerolox-Lower
-        transformName = H-1-ThrustTransform
-        localRotation = 0,0,0 
-        plumePosition = 0,0,1
-		plumeScale = 0.6
-		flarePosition = 0,0,0.85
-        flareScale = 0.9
-        energy = 1
-        speed = 1		
-    }
+	PLUME_TEMPLATE
+	{
+		name = Kerolox_LowerFlame
+		transformName = H-1-ThrustTransform
+		scale = 0.71
+		offset = 0.8
+	}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
@@ -49,7 +39,7 @@
 		%type = ModuleEnginesRF
         @CONFIG,*
 		{
-			%powerEffectName = Kerolox-Lower
+			%powerEffectName = Kerolox_LowerFlame
 		}
 	}
 }

--- a/GameData/ROEngines/RealPlume/H1_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/H1_SSTU_RealPlume.cfg
@@ -2,7 +2,7 @@
 {
 	PLUME_TEMPLATE
 	{
-		name = Kerolox_LowerAlt
+		name = Cryogenic_UpperBlue_CE
 		transformName = H-1-ThrustTransform
 		scale = 0.71
 		offset = 0.8
@@ -11,21 +11,21 @@
 	{
 		@name = ModuleEnginesRF
 	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		%type = ModuleEnginesRF
-        @CONFIG,*
-		{
-			%powerEffectName = Kerolox_LowerAlt
-		}
-	}
+	//@MODULE[ModuleEngineConfigs]
+	//{
+	//	%type = ModuleEnginesRF
+    //    @CONFIG,*
+	//	{
+	//		%powerEffectName = Kerolox_LowerAlt
+	//	}
+	//}
 }
 
 @PART[ROE-H1D]:NEEDS[RealPlume]:BEFORE[RealPlume]
 {
 	PLUME_TEMPLATE
 	{
-		name = Kerolox_LowerFlame
+		name = Hydrolox_UpperBlue
 		transformName = H-1-ThrustTransform
 		scale = 0.71
 		offset = 0.8
@@ -34,12 +34,12 @@
 	{
 		@name = ModuleEnginesRF
 	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		%type = ModuleEnginesRF
-        @CONFIG,*
-		{
-			%powerEffectName = Kerolox_LowerFlame
-		}
-	}
+	//@MODULE[ModuleEngineConfigs]
+	//{
+	//	%type = ModuleEnginesRF
+    //    @CONFIG,*
+	//	{
+	//		%powerEffectName = Kerolox_LowerFlame
+	//	}
+	//}
 }

--- a/GameData/ROEngines/RealPlume/H1_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/H1_SSTU_RealPlume.cfg
@@ -1,45 +1,29 @@
 @PART[ROE-H1C]:NEEDS[RealPlume]:BEFORE[RealPlume]
 {
-	PLUME_TEMPLATE
-	{
-		name = Kerolox_LowerAlt
-		transformName = H-1-ThrustTransform
-		scale = 0.71
-		offset = 0.8
-	}
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
-	//@MODULE[ModuleEngineConfigs]
-	//{
-	//	%type = ModuleEnginesRF
-    //    @CONFIG,*
-	//	{
-	//		%powerEffectName = Kerolox_LowerAlt
-	//	}
-	//}
+    PLUME_TEMPLATE
+    {
+        name = Kerolox_LowerAlt
+        transformName = H-1-ThrustTransform
+        scale = 0.71
+        offset = 0.8
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
 }
 
 @PART[ROE-H1D]:NEEDS[RealPlume]:BEFORE[RealPlume]
 {
-	PLUME_TEMPLATE
-	{
-		name = Kerolox_LowerFlame
-		transformName = H-1-ThrustTransform
-		scale = 0.71
-		offset = 0.8
-	}
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
-	//@MODULE[ModuleEngineConfigs]
-	//{
-	//	%type = ModuleEnginesRF
-    //    @CONFIG,*
-	//	{
-	//		%powerEffectName = Kerolox_LowerFlame
-	//	}
-	//}
+    PLUME_TEMPLATE
+    {
+        name = Kerolox_LowerFlame
+        transformName = H-1-ThrustTransform
+        scale = 0.71
+        offset = 0.8
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
 }

--- a/GameData/ROEngines/RealPlume/HiPAT_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/HiPAT_NicheParts_RealPlume.cfg
@@ -1,24 +1,18 @@
 @PART[ROE-HiPAT]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs],*
+	//@MODULE[ModuleEngineConfigs],*
+    //{
+	//	%type = ModuleEnginesRF
+    //    @CONFIG,*
+    //    {
+    //        %powerEffectName = Hypergolic-OMS-White
+    //    }
+	//}
+    PLUME_TEMPLATE
     {
-		%type = ModuleEnginesRF
-        @CONFIG,*
-        {
-            %powerEffectName = Hypergolic-OMS-White
-        }
-	}
-    PLUME
-    {
-        name = Hypergolic-OMS-White
+        name = Hypergolic_UpperRed
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, -0.5
-        flareScale =    0.35
-        plumePosition = 0.0, 0.0, -0.5
-        plumeScale =    0.35
-        fixedScale =	0.35
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        scale = 0.2135
+		offset = 0
     }
 }

--- a/GameData/ROEngines/RealPlume/HiPAT_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/HiPAT_NicheParts_RealPlume.cfg
@@ -1,18 +1,10 @@
 @PART[ROE-HiPAT]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	//@MODULE[ModuleEngineConfigs],*
-    //{
-	//	%type = ModuleEnginesRF
-    //    @CONFIG,*
-    //    {
-    //        %powerEffectName = Hypergolic-OMS-White
-    //    }
-	//}
     PLUME_TEMPLATE
     {
         name = Hypergolic_UpperRed
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.2135
-		offset = 0
+        offset = 0
     }
 }

--- a/GameData/ROEngines/RealPlume/J2X_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/J2X_SSTU_RealPlume.cfg
@@ -1,9 +1,9 @@
 @PART[ROE-J2X]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesFX
-		%powerEffectName = Hydrolox-Upper
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesFX
+        %powerEffectName = Hydrolox-Upper
     }
     PLUME
     {
@@ -12,8 +12,8 @@
         localRotation = 0,0,0
         plumePosition = 0,0,3.75
         plumeScale = 4
-		flarePosition = 0,0,3.75
-		flareScale = 4
+        flarePosition = 0,0,3.75
+        flareScale = 4
         energy = 1.0
         speed = 1
     }

--- a/GameData/ROEngines/RealPlume/J2_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/J2_SSTU_RealPlume.cfg
@@ -1,9 +1,9 @@
 @PART[ROE-J2]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesFX
-		%powerEffectName = Hydrolox-Upper
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesFX
+        %powerEffectName = Hydrolox-Upper
     }
     PLUME
     {
@@ -12,8 +12,8 @@
         localRotation = 0,0,0
         plumePosition = 0,0,2.5
         plumeScale = 2.2
-		flarePosition = 0,0,2.05
-		flareScale = 2.2
+        flarePosition = 0,0,2.05
+        flareScale = 2.2
         energy = 1.0
         speed = 1
     }

--- a/GameData/ROEngines/RealPlume/J2_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/J2_SSTU_RealPlume.cfg
@@ -10,7 +10,7 @@
         name = Hydrolox-Upper
         transformName = J-2-ThrustTransform
         localRotation = 0,0,0
-        plumePosition = 0,0,2.2
+        plumePosition = 0,0,2.5
         plumeScale = 2.2
 		flarePosition = 0,0,2.05
 		flareScale = 2.2

--- a/GameData/ROEngines/RealPlume/LEROS1B_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LEROS1B_NicheParts_RealPlume.cfg
@@ -1,24 +1,18 @@
 @PART[ROE-LEROS1B]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs],*
+	//@MODULE[ModuleEngineConfigs],*
+    //{
+	//	%type = ModuleEnginesRF
+    //    @CONFIG,*
+    //    {
+    //        %powerEffectName = Hypergolic-OMS-White
+    //    }
+	//}
+    PLUME_TEMPLATE
     {
-		%type = ModuleEnginesRF
-        @CONFIG,*
-        {
-            %powerEffectName = Hypergolic-OMS-White
-        }
-	}
-    PLUME
-    {
-        name = Hypergolic-OMS-White
+        name = Hypergolic_UpperRed
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, -0.5
-        flareScale =    0.3
-        plumePosition = 0.0, 0.0, -0.5
-        plumeScale =    0.3
-        fixedScale =	0.3
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        scale = 0.1591
+		offset = 0.1
     }
 }

--- a/GameData/ROEngines/RealPlume/LEROS1B_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LEROS1B_NicheParts_RealPlume.cfg
@@ -1,18 +1,10 @@
 @PART[ROE-LEROS1B]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	//@MODULE[ModuleEngineConfigs],*
-    //{
-	//	%type = ModuleEnginesRF
-    //    @CONFIG,*
-    //    {
-    //        %powerEffectName = Hypergolic-OMS-White
-    //    }
-	//}
     PLUME_TEMPLATE
     {
         name = Hypergolic_UpperRed
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.1591
-		offset = 0.1
+        offset = 0.1
     }
 }

--- a/GameData/ROEngines/RealPlume/LEROS4_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LEROS4_NicheParts_RealPlume.cfg
@@ -1,24 +1,18 @@
 @PART[ROE-LEROS4]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs],*
+	//@MODULE[ModuleEngineConfigs],*
+    //{
+	//	%type = ModuleEnginesRF
+    //    @CONFIG,*
+    //    {
+    //        %powerEffectName = Hypergolic-OMS-White
+    //    }
+	//}
+    PLUME_TEMPLATE
     {
-		%type = ModuleEnginesRF
-        @CONFIG,*
-        {
-            %powerEffectName = Hypergolic-OMS-White
-        }
-	}
-    PLUME
-    {
-        name = Hypergolic-OMS-White
+        name = Hypergolic_UpperRed
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, -0.3
-        flareScale =    0.5
-        plumePosition = 0.0, 0.0, -0.3
-        plumeScale =    0.5
-        fixedScale =	0.5
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        scale = 0.2841
+		offset = 0.05
     }
 }

--- a/GameData/ROEngines/RealPlume/LEROS4_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LEROS4_NicheParts_RealPlume.cfg
@@ -1,18 +1,10 @@
 @PART[ROE-LEROS4]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	//@MODULE[ModuleEngineConfigs],*
-    //{
-	//	%type = ModuleEnginesRF
-    //    @CONFIG,*
-    //    {
-    //        %powerEffectName = Hypergolic-OMS-White
-    //    }
-	//}
     PLUME_TEMPLATE
     {
         name = Hypergolic_UpperRed
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.2841
-		offset = 0.05
+        offset = 0.05
     }
 }

--- a/GameData/ROEngines/RealPlume/LR101_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR101_BDB_RealPlume.cfg
@@ -1,13 +1,13 @@
 @PART[ROE-LR101Inline]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		%powerEffectName = Kerolox_VernierEagle
-	}
-	@MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleEngines*]
     {
-		%type = ModuleEnginesRF
+        @name = ModuleEnginesRF
+        %powerEffectName = Kerolox_VernierEagle
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
     }
     PLUME
     {
@@ -23,14 +23,14 @@
 
 @PART[ROE-LR101]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		%powerEffectName = Kerolox_VernierEagle
-	}
-	@MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleEngines*]
     {
-		%type = ModuleEnginesRF
+        @name = ModuleEnginesRF
+        %powerEffectName = Kerolox_VernierEagle
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
     }
     PLUME
     {

--- a/GameData/ROEngines/RealPlume/LR101_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR101_BDB_RealPlume.cfg
@@ -14,7 +14,7 @@
         name = Kerolox_VernierEagle
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.1
+        localPosition = 0,0,0.07
         fixedScale = 0.2
         energy = 1
         speed = 1.5

--- a/GameData/ROEngines/RealPlume/LR101_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR101_BDB_RealPlume.cfg
@@ -3,7 +3,7 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
-		%powerEffectName = Kerolox-Vernier
+		%powerEffectName = Kerolox_VernierEagle
 	}
 	@MODULE[ModuleEngineConfigs]
     {
@@ -11,7 +11,7 @@
     }
     PLUME
     {
-        name = Kerolox-Vernier
+        name = Kerolox_VernierEagle
         transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,0.06

--- a/GameData/ROEngines/RealPlume/LR101_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR101_BDB_RealPlume.cfg
@@ -14,8 +14,8 @@
         name = Kerolox_VernierEagle
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.06
-        fixedScale = 1.2
+        localPosition = 0,0,0.1
+        fixedScale = 0.2
         energy = 1
         speed = 1.5
     }
@@ -26,7 +26,7 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
-		%powerEffectName = Kerolox-Vernier
+		%powerEffectName = Kerolox_VernierEagle
 	}
 	@MODULE[ModuleEngineConfigs]
     {
@@ -34,11 +34,11 @@
     }
     PLUME
     {
-        name = Kerolox-Vernier
+        name = Kerolox_VernierEagle
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.06
-        fixedScale = 1.2
+        localPosition = 0,0,0.1
+        fixedScale = 0.2
         energy = 1
         speed = 1.5
     }

--- a/GameData/ROEngines/RealPlume/LR101_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR101_BDB_RealPlume.cfg
@@ -14,8 +14,8 @@
         name = Kerolox-Vernier
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0
-        fixedScale = 0.7
+        localPosition = 0,0,0.06
+        fixedScale = 1.2
         energy = 1
         speed = 1.5
     }
@@ -37,8 +37,8 @@
         name = Kerolox-Vernier
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0
-        fixedScale = 0.7
+        localPosition = 0,0,0.06
+        fixedScale = 1.2
         energy = 1
         speed = 1.5
     }

--- a/GameData/ROEngines/RealPlume/LR105_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR105_BDB_RealPlume.cfg
@@ -1,19 +1,10 @@
 @PART[ROE-LR105]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	//@MODULE[ModuleEngines*]
-	//{
-	//	@name = ModuleEnginesRF
-	//	%powerEffectName = Kerolox-Lower
-	//}
-	//@MODULE[ModuleEngineConfigs]
-    //{
-	//	%type = ModuleEnginesRF
-    //}
     PLUME_TEMPLATE
     {
         name = Kerolox_LowerFlame
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.722
-		offset = 0.1
+        offset = 0.1
     }
 }

--- a/GameData/ROEngines/RealPlume/LR105_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR105_BDB_RealPlume.cfg
@@ -16,7 +16,7 @@
         flarePosition = 0.0, 0.0, 0.25
         flareScale =    1.0
         plumePosition = 0.0, 0.0, 0.3
-        plumeScale =    0.7
+        plumeScale =    0.6
         //fixedScale = 1.0
 		energy = 1.0
         speed = 1.0

--- a/GameData/ROEngines/RealPlume/LR105_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR105_BDB_RealPlume.cfg
@@ -1,25 +1,19 @@
 @PART[ROE-LR105]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		%powerEffectName = Kerolox-Lower
-	}
-	@MODULE[ModuleEngineConfigs]
+	//@MODULE[ModuleEngines*]
+	//{
+	//	@name = ModuleEnginesRF
+	//	%powerEffectName = Kerolox-Lower
+	//}
+	//@MODULE[ModuleEngineConfigs]
+    //{
+	//	%type = ModuleEnginesRF
+    //}
+    PLUME_TEMPLATE
     {
-		%type = ModuleEnginesRF
-    }
-    PLUME
-    {
-        name = Kerolox-Lower
+        name = Kerolox_LowerFlame
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.25
-        flareScale =    1.0
-        plumePosition = 0.0, 0.0, 0.3
-        plumeScale =    0.6
-        //fixedScale = 1.0
-		energy = 1.0
-        speed = 1.0
-        emissionMult = 0.5
+        scale = 0.722
+		offset = 0.1
     }
 }

--- a/GameData/ROEngines/RealPlume/LR79_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR79_BDB_RealPlume.cfg
@@ -1,25 +1,19 @@
 @PART[ROE-LR79]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		%powerEffectName = Kerolox-Lower
-	}
-	@MODULE[ModuleEngineConfigs]
+	//@MODULE[ModuleEngines*]
+	//{
+	//	@name = ModuleEnginesRF
+	//	%powerEffectName = Kerolox-Lower
+	//}
+	//@MODULE[ModuleEngineConfigs]
+    //{
+	//	%type = ModuleEnginesRF
+    //}
+	PLUME_TEMPLATE
     {
-		%type = ModuleEnginesRF
-    }
-	PLUME
-    {
-        name = Kerolox-Lower
+        name = Kerolox_LowerFlame
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.1
-        flareScale =    1.0
-        plumePosition = 0.0, 0.0, 0.3
-        plumeScale =    0.7
-        fixedScale = 1.0
-		energy = 1.0
-        speed = 1.0
-        emissionMult = 0.5
+        scale = 0.666
+		offset = 1.5
     }
 }

--- a/GameData/ROEngines/RealPlume/LR79_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR79_BDB_RealPlume.cfg
@@ -1,19 +1,10 @@
 @PART[ROE-LR79]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	//@MODULE[ModuleEngines*]
-	//{
-	//	@name = ModuleEnginesRF
-	//	%powerEffectName = Kerolox-Lower
-	//}
-	//@MODULE[ModuleEngineConfigs]
-    //{
-	//	%type = ModuleEnginesRF
-    //}
-	PLUME_TEMPLATE
+    PLUME_TEMPLATE
     {
         name = Kerolox_LowerFlame
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.666
-		offset = 1.5
+        offset = 1.5
     }
 }

--- a/GameData/ROEngines/RealPlume/LR79_RN_RealPlume.cfg.bak
+++ b/GameData/ROEngines/RealPlume/LR79_RN_RealPlume.cfg.bak
@@ -1,18 +1,12 @@
 @PART[ROE-LR79]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
-    {
-        name = Kerolox-Lower
+	PLUME_TEMPLATE
+	{
+		name = Kerolox_LowerFlame
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.1
-        flareScale =    1.0
-        plumePosition = 0.0, 0.0, 0.3
-        plumeScale =    0.7
-        fixedScale = 1.0
-		energy = 1.0
-        speed = 1.0
-        emissionMult = 0.5
-    }
+		scale = 0.7777
+		offset = 0
+	}
 	PLUME
     {
         name = Kerolox-Exhaust
@@ -26,7 +20,7 @@
 {
     @EFFECTS
     {
-        @Kerolox-Lower
+        @Kerolox_LowerFlame
         {
             |_ = CombinedPlume
         }

--- a/GameData/ROEngines/RealPlume/LR87_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR87_RN_RealPlume.cfg
@@ -6,6 +6,7 @@
 		transformName = thrustTransform
         scale = 0.85
 		offset = 0.1
+		setupEngine = false
     }
 	PLUME
     {
@@ -26,6 +27,7 @@
 		transformName = thrustTransform
 		scale = 0.85
 		offset = -0.1
+		setupEngine = false
 	}
 	PLUME
     {

--- a/GameData/ROEngines/RealPlume/LR87_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR87_RN_RealPlume.cfg
@@ -1,17 +1,11 @@
 @PART[ROE-LR87]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    PLUME
+    PLUME_TEMPLATE
     {
-        name = Hypergolic-Lower
+        name = Hypergolic_LowerRed_shock
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.396
-        flareScale =    1.2
-        plumePosition = 0.0, 0.0, 0.002
-        plumeScale =    1.3
-        fixedScale = 1.0
-		energy = 1.0
-        speed = 1.0
-        emissionMult = 1.0
+        scale = 0.85
+		offset = 0.1
     }
 	PLUME
     {
@@ -30,8 +24,8 @@
 	{
 		name = Kerolox_LowerFlame
 		transformName = thrustTransform
-		scale = 1
-		offset = 0
+		scale = 0.85
+		offset = -0.1
 	}
 	PLUME
     {
@@ -41,11 +35,88 @@
         fixedScale =    2.5
     }
 }
+@PART[ROE-LR87]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
+{
+	//this is just fixing for some weird model issues, seems it was rescaled in blender/unity
+	@PLUME[Hypergolic_LowerRed]
+	{
+		@flarePosition[2] *= 0.01
+		@plumePosition[2] *= 0.01
+		@fumePosition[2] *= 0.01
+		@blazePosition[2] *= 0.01
+	}	
+	@PLUME[Kerolox_LowerFlame]
+	{
+		@plumePosition[2] *= 0.01
+		@flamePosition[2] *= 0.01
+	    @flarePosition[2] *= 0.01
+	}
+}
+
 @PART[ROE-LR87]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
 {
     @EFFECTS
     {
-        @Hypergolic-Lower
+		@Hypergolic_LowerRed
+		{
+			//more fixing
+			@MODEL_MULTI_SHURIKEN_PERSIST[blaze]
+			{
+				@offset *= 0.01
+			}
+			@MODEL_MULTI_SHURIKEN_PERSIST[plume]
+			{
+				@offset
+				{
+					@density,1 = 0.02 0.003
+				}
+			}
+			
+			@MODEL_MULTI_SHURIKEN_PERSIST[dia1]
+			{
+				@localPosition = 0,0,-3.59
+			}
+			@MODEL_MULTI_SHURIKEN_PERSIST[dia2]
+			{
+				@localPosition = 0,0,-8.158
+			}
+			@MODEL_MULTI_SHURIKEN_PERSIST[dia3]
+			{
+				@localPosition = 0,0,-12.234315
+			}
+			@MODEL_MULTI_SHURIKEN_PERSIST[shock2]
+			{
+				@localPosition = 0,0,-4.731
+			}
+			@MODEL_MULTI_SHURIKEN_PERSIST[shock3]
+			{
+				@localPosition = 0,0,-8.971315
+			}
+			@MODEL_MULTI_SHURIKEN_PERSIST[shock4]
+			{
+				@localPosition = 0,0,-13.0504315
+			}
+		}
+		
+		@Kerolox_LowerFlame
+        {
+            @MODEL_MULTI_SHURIKEN_PERSIST[Kerolox_LowerFlame-plume2]
+			{
+				@offset *= 0.01
+				@localPosition = 0,0,-0.04059445
+			}
+			@MODEL_MULTI_SHURIKEN_PERSIST[Kerolox_LowerFlame-plume3]
+			{
+				@offset *= 0.01
+				@localPosition = 0,0,-0.03959445
+			}
+			@MODEL_MULTI_SHURIKEN_PERSIST[Kerolox_LowerFlame-blaze]
+			{
+				@offset *= 0.01
+			}
+        }
+	
+        @Hypergolic_LowerRed
         {
             |_ = CombinedPlumeHypergolic
         }

--- a/GameData/ROEngines/RealPlume/LR87_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR87_RN_RealPlume.cfg
@@ -4,8 +4,8 @@
     {
         name = Hypergolic-Lower
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.0
-        flareScale =    0.8
+        flarePosition = 0.0, 0.0, 0.396
+        flareScale =    1.2
         plumePosition = 0.0, 0.0, 0.002
         plumeScale =    1.3
         fixedScale = 1.0
@@ -19,7 +19,7 @@
 		transformName = newThrustTransform
         flarePosition = 0.0, 0.0, 0.0
         flareScale =    0.0
-        plumePosition = 0.0, 0.0, 1.35
+        plumePosition = 0.0, 0.0, 1.5
         plumeScale =    1.5
         fixedScale =	1.0
 		energy = 0.5
@@ -43,7 +43,7 @@
     {
         name = Kerolox-Exhaust
 		transformName = newThrustTransform
-        localPosition = 0.0, 0.0, 0.35
+        localPosition = 0.0, 0.0, 0.5
         fixedScale =    2.5
     }
 }

--- a/GameData/ROEngines/RealPlume/LR87_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR87_RN_RealPlume.cfg
@@ -3,121 +3,121 @@
     PLUME_TEMPLATE
     {
         name = Hypergolic_LowerRed_shock
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.85
-		offset = 0.1
-		setupEngine = false
+        offset = 0.1
+        setupEngine = false
     }
-	PLUME
+    PLUME
     {
         name = Hypergolic-Vernier
-		transformName = newThrustTransform
+        transformName = newThrustTransform
         flarePosition = 0.0, 0.0, 0.0
         flareScale =    0.0
         plumePosition = 0.0, 0.0, 1.5
         plumeScale =    1.5
-        fixedScale =	1.0
-		energy = 0.5
+        fixedScale =    1.0
+        energy = 0.5
         speed = 1.0
         emissionMult = 0.5
     }
-	PLUME_TEMPLATE
-	{
-		name = Kerolox_LowerFlame
-		transformName = thrustTransform
-		scale = 0.85
-		offset = -0.1
-		setupEngine = false
-	}
-	PLUME
+    PLUME_TEMPLATE
+    {
+        name = Kerolox_LowerFlame
+        transformName = thrustTransform
+        scale = 0.85
+        offset = -0.1
+        setupEngine = false
+    }
+    PLUME
     {
         name = Kerolox-Exhaust
-		transformName = newThrustTransform
+        transformName = newThrustTransform
         localPosition = 0.0, 0.0, 0.5
         fixedScale =    2.5
     }
 }
 @PART[ROE-LR87]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
 {
-	//this is just fixing for some weird model issues, seems it was rescaled in blender/unity
-	@PLUME[Hypergolic_LowerRed]
-	{
-		@flarePosition[2] *= 0.01
-		@plumePosition[2] *= 0.01
-		@fumePosition[2] *= 0.01
-		@blazePosition[2] *= 0.01
-	}	
-	@PLUME[Kerolox_LowerFlame]
-	{
-		@plumePosition[2] *= 0.01
-		@flamePosition[2] *= 0.01
-	    @flarePosition[2] *= 0.01
-	}
+    //this is just fixing for some weird model issues, seems it was rescaled in blender/unity
+    @PLUME[Hypergolic_LowerRed]
+    {
+        @flarePosition[2] *= 0.01
+        @plumePosition[2] *= 0.01
+        @fumePosition[2] *= 0.01
+        @blazePosition[2] *= 0.01
+    }   
+    @PLUME[Kerolox_LowerFlame]
+    {
+        @plumePosition[2] *= 0.01
+        @flamePosition[2] *= 0.01
+        @flarePosition[2] *= 0.01
+    }
 }
 
 @PART[ROE-LR87]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
 {
     @EFFECTS
     {
-		@Hypergolic_LowerRed
-		{
-			//more fixing
-			@MODEL_MULTI_SHURIKEN_PERSIST[blaze]
-			{
-				@offset *= 0.01
-			}
-			@MODEL_MULTI_SHURIKEN_PERSIST[plume]
-			{
-				@offset
-				{
-					@density,1 = 0.02 0.003
-				}
-			}
-			
-			@MODEL_MULTI_SHURIKEN_PERSIST[dia1]
-			{
-				@localPosition = 0,0,-3.59
-			}
-			@MODEL_MULTI_SHURIKEN_PERSIST[dia2]
-			{
-				@localPosition = 0,0,-8.158
-			}
-			@MODEL_MULTI_SHURIKEN_PERSIST[dia3]
-			{
-				@localPosition = 0,0,-12.234315
-			}
-			@MODEL_MULTI_SHURIKEN_PERSIST[shock2]
-			{
-				@localPosition = 0,0,-4.731
-			}
-			@MODEL_MULTI_SHURIKEN_PERSIST[shock3]
-			{
-				@localPosition = 0,0,-8.971315
-			}
-			@MODEL_MULTI_SHURIKEN_PERSIST[shock4]
-			{
-				@localPosition = 0,0,-13.0504315
-			}
-		}
-		
-		@Kerolox_LowerFlame
+        @Hypergolic_LowerRed
+        {
+            //more fixing
+            @MODEL_MULTI_SHURIKEN_PERSIST[blaze]
+            {
+                @offset *= 0.01
+            }
+            @MODEL_MULTI_SHURIKEN_PERSIST[plume]
+            {
+                @offset
+                {
+                    @density,1 = 0.02 0.003
+                }
+            }
+            
+            @MODEL_MULTI_SHURIKEN_PERSIST[dia1]
+            {
+                @localPosition = 0,0,-3.59
+            }
+            @MODEL_MULTI_SHURIKEN_PERSIST[dia2]
+            {
+                @localPosition = 0,0,-8.158
+            }
+            @MODEL_MULTI_SHURIKEN_PERSIST[dia3]
+            {
+                @localPosition = 0,0,-12.234315
+            }
+            @MODEL_MULTI_SHURIKEN_PERSIST[shock2]
+            {
+                @localPosition = 0,0,-4.731
+            }
+            @MODEL_MULTI_SHURIKEN_PERSIST[shock3]
+            {
+                @localPosition = 0,0,-8.971315
+            }
+            @MODEL_MULTI_SHURIKEN_PERSIST[shock4]
+            {
+                @localPosition = 0,0,-13.0504315
+            }
+        }
+        
+        @Kerolox_LowerFlame
         {
             @MODEL_MULTI_SHURIKEN_PERSIST[Kerolox_LowerFlame-plume2]
-			{
-				@offset *= 0.01
-				@localPosition = 0,0,-0.04059445
-			}
-			@MODEL_MULTI_SHURIKEN_PERSIST[Kerolox_LowerFlame-plume3]
-			{
-				@offset *= 0.01
-				@localPosition = 0,0,-0.03959445
-			}
-			@MODEL_MULTI_SHURIKEN_PERSIST[Kerolox_LowerFlame-blaze]
-			{
-				@offset *= 0.01
-			}
+            {
+                @offset *= 0.01
+                @localPosition = 0,0,-0.04059445
+            }
+            @MODEL_MULTI_SHURIKEN_PERSIST[Kerolox_LowerFlame-plume3]
+            {
+                @offset *= 0.01
+                @localPosition = 0,0,-0.03959445
+            }
+            @MODEL_MULTI_SHURIKEN_PERSIST[Kerolox_LowerFlame-blaze]
+            {
+                @offset *= 0.01
+            }
         }
-	
+    
         @Hypergolic_LowerRed
         {
             |_ = CombinedPlumeHypergolic

--- a/GameData/ROEngines/RealPlume/LR87_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR87_RN_RealPlume.cfg
@@ -26,19 +26,13 @@
         speed = 1.0
         emissionMult = 0.5
     }
-	PLUME
-    {
-        name = Kerolox-Lower
+	PLUME_TEMPLATE
+	{
+		name = Kerolox_LowerFlame
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.0
-        flareScale =    0.8
-        plumePosition = 0.0, 0.0, 0.001
-        plumeScale =    1.3
-        fixedScale = 1.0
-		energy = 1.0
-        speed = 1.0
-        emissionMult = 1.0
-    }
+		scale = 1
+		offset = 0
+	}
 	PLUME
     {
         name = Kerolox-Exhaust
@@ -59,7 +53,7 @@
         {
             |_ = CombinedPlumeHypergolic
         }
-        @Kerolox-Lower
+        @Kerolox_LowerFlame
         {
             |_ = CombinedPlumeKerolox
         }

--- a/GameData/ROEngines/RealPlume/LR89_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR89_BDB_RealPlume.cfg
@@ -1,25 +1,19 @@
 @PART[ROE-LR89]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		%powerEffectName = Kerolox-Lower
-	}
-	@MODULE[ModuleEngineConfigs]
+	//@MODULE[ModuleEngines*]
+	//{
+	//	@name = ModuleEnginesRF
+	//	%powerEffectName = Kerolox-Lower
+	//}
+	//@MODULE[ModuleEngineConfigs]
+    //{
+	//	%type = ModuleEnginesRF
+    //}
+    PLUME_TEMPLATE
     {
-		%type = ModuleEnginesRF
-    }
-    PLUME
-    {
-        name = Kerolox-Lower
+        name = Kerolox_LowerFlame
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.15
-        flareScale =    0.8
-        plumePosition = 0.0, 0.0, 0.39
-        plumeScale =    0.6
-        //fixedScale = 1.0
-		energy = 1.0
-        speed = 1.0
-        emissionMult = 0.5
+        scale = 0.667
+		offset = 0.13
     }
 }

--- a/GameData/ROEngines/RealPlume/LR89_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR89_BDB_RealPlume.cfg
@@ -13,10 +13,10 @@
     {
         name = Kerolox-Lower
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.25
-        flareScale =    0.9
-        plumePosition = 0.0, 0.0, 0.3
-        plumeScale =    0.7
+        flarePosition = 0.0, 0.0, 0.15
+        flareScale =    0.8
+        plumePosition = 0.0, 0.0, 0.39
+        plumeScale =    0.6
         //fixedScale = 1.0
 		energy = 1.0
         speed = 1.0

--- a/GameData/ROEngines/RealPlume/LR89_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR89_BDB_RealPlume.cfg
@@ -1,19 +1,10 @@
 @PART[ROE-LR89]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	//@MODULE[ModuleEngines*]
-	//{
-	//	@name = ModuleEnginesRF
-	//	%powerEffectName = Kerolox-Lower
-	//}
-	//@MODULE[ModuleEngineConfigs]
-    //{
-	//	%type = ModuleEnginesRF
-    //}
     PLUME_TEMPLATE
     {
         name = Kerolox_LowerFlame
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.667
-		offset = 0.13
+        offset = 0.13
     }
 }

--- a/GameData/ROEngines/RealPlume/LR91_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR91_RN_RealPlume.cfg
@@ -23,8 +23,8 @@
     {
         name = Hypergolic-Upper
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.0
-        flareScale =    1.65
+        flarePosition = 0.0, 0.0, 0.396
+        flareScale =    1.7
         plumePosition = 0.0, 0.0, 0.008
         plumeScale =    2.0
         fixedScale =	1.0
@@ -36,7 +36,7 @@
     {
         name = Hypergolic-Vernier
 		transformName = vernierThrust
-        plumePosition = 0.0, 0.0, 0.01
+        plumePosition = 0.0, 0.0, 1
         plumeScale =    0.7
         fixedScale =	1.0
 		energy = 0.2
@@ -47,10 +47,10 @@
     {
         name = Kerolox-Upper
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.0
-        flareScale =    1.65
-        plumePosition = 0.0, 0.0, 0.003
-        plumeScale =    2.0
+        flarePosition = 0.0, 0.0, -0.005
+        flareScale =    1
+        plumePosition = 0.0, 0.0, -0.001
+        plumeScale =    0.7
         fixedScale =	1.0
 		energy = 1.0
         speed = 1.0
@@ -60,8 +60,8 @@
     {
         name = Kerolox-Vernier
 		transformName = vernierThrust
-        plumePosition = 0.0, 0.0, 0.01
-        plumeScale =    0.7
+        localPosition = 0.0, 0.0, 0.0007
+        plumeScale =    1.5
         fixedScale =	1.0
 		energy = 0.2
         speed = 1.0

--- a/GameData/ROEngines/RealPlume/LR91_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR91_RN_RealPlume.cfg
@@ -1,69 +1,69 @@
 @PART[ROE-LR91]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs],*
+    @MODULE[ModuleEngineConfigs],*
     {
-		%type = ModuleEnginesRF
+        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-Upper
-			%runningEffectName = Hypergolic-Vernier
+            %runningEffectName = Hypergolic-Vernier
         }
-		@CONFIG[LR91-AJ-3]
-		{
-			%powerEffectName = Kerolox-Upper
-			%runningEffectName = Kerolox-Vernier
-		}
-		@CONFIG[LR91-AJ-9-Kero]
-		{
-			%powerEffectName = Kerolox-Upper
-			%runningEffectName = Kerolox-Vernier
-		}
+        @CONFIG[LR91-AJ-3]
+        {
+            %powerEffectName = Kerolox-Upper
+            %runningEffectName = Kerolox-Vernier
+        }
+        @CONFIG[LR91-AJ-9-Kero]
+        {
+            %powerEffectName = Kerolox-Upper
+            %runningEffectName = Kerolox-Vernier
+        }
     }
     PLUME
     {
         name = Hypergolic-Upper
-		transformName = thrustTransform
+        transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.396
         flareScale =    1.7
         plumePosition = 0.0, 0.0, 0.008
         plumeScale =    2.0
-        fixedScale =	1.0
-		energy = 1.0
+        fixedScale =    1.0
+        energy = 1.0
         speed = 1.0
         emissionMult = 0.5
     }
-	PLUME
+    PLUME
     {
         name = Hypergolic-Vernier
-		transformName = vernierThrust
+        transformName = vernierThrust
         plumePosition = 0.0, 0.0, 1
         plumeScale =    0.7
-        fixedScale =	1.0
-		energy = 0.2
+        fixedScale =    1.0
+        energy = 0.2
         speed = 1.0
         emissionMult = 0.5
     }
-	PLUME
+    PLUME
     {
         name = Kerolox-Upper
-		transformName = thrustTransform
+        transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.005
         flareScale =    1
         plumePosition = 0.0, 0.0, -0.001
         plumeScale =    0.7
-        fixedScale =	1.0
-		energy = 1.0
+        fixedScale =    1.0
+        energy = 1.0
         speed = 1.0
         emissionMult = 0.5
     }
-	PLUME
+    PLUME
     {
         name = Kerolox-Vernier
-		transformName = vernierThrust
+        transformName = vernierThrust
         localPosition = 0.0, 0.0, 0.0007
         plumeScale =    1.5
-        fixedScale =	1.0
-		energy = 0.2
+        fixedScale =    1.0
+        energy = 0.2
         speed = 1.0
         emissionMult = 0.5
     }

--- a/GameData/ROEngines/RealPlume/MR104_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/MR104_NicheParts_RealPlume.cfg
@@ -4,27 +4,22 @@
     {
         name = Hypergolic-OMS-White
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, -0.625
-        flareScale =    0.2
-        plumePosition = 0.0, 0.0, 0.0
+        flarePosition = 0.0, 0.0, -0.855
+        flareScale =    0.05
+        plumePosition = 0.0, 0.0, 0.09
         plumeScale =    0.2
         fixedScale =	0.2
 		energy = 		1.0
         speed = 		1.0
         emissionMult = 	1.0
     }
-	PLUME
+	PLUME_TEMPLATE
     {
-        name = Hypergolic-OMS-Red
+        name = Hypergolic_UpperRed
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.525
-        flareScale =    0.2
-        plumePosition = 0.0, 0.0, 0.525
-        plumeScale =    0.2
-        fixedScale =	0.2
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        scale = 0.09
+		offset = 0.0
+		setupEngine = false
     }
 }
 
@@ -39,27 +34,27 @@
 
         @CONFIG[MMH+NTO]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
 
         @CONFIG[MMH+MON3]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
 
         @CONFIG[UDMH+NTO]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
 
         @CONFIG[Aerozine50+NTO]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
 
         @CONFIG[Cavea-B]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
     }
 }

--- a/GameData/ROEngines/RealPlume/MR104_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/MR104_NicheParts_RealPlume.cfg
@@ -3,23 +3,23 @@
     PLUME
     {
         name = Hypergolic-OMS-White
-		transformName = thrustTransform
+        transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.855
         flareScale =    0.05
         plumePosition = 0.0, 0.0, 0.09
         plumeScale =    0.2
-        fixedScale =	0.2
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        fixedScale =    0.2
+        energy =        1.0
+        speed =         1.0
+        emissionMult =  1.0
     }
-	PLUME_TEMPLATE
+    PLUME_TEMPLATE
     {
         name = Hypergolic_UpperRed
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.09
-		offset = 0.0
-		setupEngine = false
+        offset = 0.0
+        setupEngine = false
     }
 }
 

--- a/GameData/ROEngines/RealPlume/MR80B_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/MR80B_NicheParts_RealPlume.cfg
@@ -1,18 +1,18 @@
 @PART[ROE-MR80B]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs],*
+    @MODULE[ModuleEngineConfigs],*
     {
-		%type = ModuleEnginesRF
+        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-Lower
         }
-	}
+    }
     PLUME_TEMPLATE
     {
         name = Hypergolic_UpperWhite
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.096
-		offset = -0.02
+        offset = -0.02
     }
 }

--- a/GameData/ROEngines/RealPlume/MR80B_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/MR80B_NicheParts_RealPlume.cfg
@@ -8,17 +8,11 @@
             %powerEffectName = Hypergolic-Lower
         }
 	}
-    PLUME
+    PLUME_TEMPLATE
     {
-        name = Hypergolic-Lower
+        name = Hypergolic_UpperWhite
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.4
-        flareScale =    0.3
-        plumePosition = 0.0, 0.0, 0.2
-        plumeScale =    0.4
-        fixedScale =	1.0
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        scale = 0.096
+		offset = -0.02
     }
 }

--- a/GameData/ROEngines/RealPlume/MR80TDE_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/MR80TDE_NicheParts_RealPlume.cfg
@@ -14,11 +14,21 @@
 		transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.45
         flareScale =    0.3
-        plumePosition = 0.0, 0.0, -0.45
+        plumePosition = 0.0, 0.0, 0.05
         plumeScale =    0.3
         fixedScale =	0.3
 		energy = 		1.0
         speed = 		1.0
         emissionMult = 	1.0
     }
+}
+@PART[ROE-MR80TDE]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+	@EFFECTS
+	{
+		@Hypergolic-OMS-White
+		{
+			!MODEL_MULTI_SHURIKEN_PERSIST[Hypergolic-OMS-White-flare] {}
+		}
+	}
 }

--- a/GameData/ROEngines/RealPlume/MR80TDE_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/MR80TDE_NicheParts_RealPlume.cfg
@@ -1,34 +1,34 @@
 @PART[ROE-MR80TDE]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs],*
+    @MODULE[ModuleEngineConfigs],*
     {
-		%type = ModuleEnginesRF
+        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-White
         }
-	}
+    }
     PLUME
     {
         name = Hypergolic-OMS-White
-		transformName = thrustTransform
+        transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.45
         flareScale =    0.3
         plumePosition = 0.0, 0.0, 0.05
         plumeScale =    0.3
-        fixedScale =	0.3
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        fixedScale =    0.3
+        energy =        1.0
+        speed =         1.0
+        emissionMult =  1.0
     }
 }
 @PART[ROE-MR80TDE]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
 {
-	@EFFECTS
-	{
-		@Hypergolic-OMS-White
-		{
-			!MODEL_MULTI_SHURIKEN_PERSIST[Hypergolic-OMS-White-flare] {}
-		}
-	}
+    @EFFECTS
+    {
+        @Hypergolic-OMS-White
+        {
+            !MODEL_MULTI_SHURIKEN_PERSIST[Hypergolic-OMS-White-flare] {}
+        }
+    }
 }

--- a/GameData/ROEngines/RealPlume/Merlin_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Merlin_SSTU_RealPlume.cfg
@@ -5,10 +5,10 @@
         name = Kerolox_LowerFlame
         transformName = Merlin-1A-MainFXTransform
         scale = 0.543
-		offset = 0.63
+        offset = 0.63
         setupEngine = false
     }
-	PLUME
+    PLUME
     {
         name = Kerolox-Exhaust
         transformName = Merlin-1A-MainFXTransform
@@ -42,15 +42,15 @@
         name = Kerolox_LowerFlame
         transformName = Merlin-1C-ThrustTransform
         scale = 0.543
-		offset = 0.83
+        offset = 0.83
         setupEngine = false
     }
-	PLUME
+    PLUME
     {
         name = Kerolox-Exhaust
         transformName = Merlin-1C-ThrustTransform
         localPosition = 0.58, 0.0, 0.2
-		localRotation = 0,9,0
+        localRotation = 0,9,0
         fixedScale = 1.5
     }
 }
@@ -76,14 +76,14 @@
 @PART[ROE-Merlin1D]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME_TEMPLATE
-	{
-		name = Kerolox_LowerFlame
-		transformName = Merlin-1D-ThrustTransform
-		scale = 0.543
-		offset = 0.83
+    {
+        name = Kerolox_LowerFlame
+        transformName = Merlin-1D-ThrustTransform
+        scale = 0.543
+        offset = 0.83
         setupEngine = false
-	}
-	PLUME
+    }
+    PLUME
     {
         name = Kerolox-Exhaust
         transformName = Merlin-1D-ThrustTransform
@@ -117,18 +117,18 @@
         name = Kerolox_Upper2
         transformName = Merlin-1CV-ThrustTransform
         scale = 1.42
-		offset = 3.45
+        offset = 3.45
         setupEngine = false
     }
-	PLUME
+    PLUME
     {
         name = Kerolox-Exhaust
         transformName = Merlin-1CV-ThrustTransform
         localPosition = 0.8, 0.0, 0.55
-		localRotation = 0,17,0
+        localRotation = 0,17,0
         fixedScale = 1.5
     }
-	
+    
 }
 @PART[ROE-Merlin1CV]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
 {
@@ -156,6 +156,6 @@
         name = Kerolox_Upper2
         transformName = Merlin-1DV-ThrustTransform
         scale = 1.42
-		offset = 3.45
+        offset = 3.45
     }
 }

--- a/GameData/ROEngines/RealPlume/Merlin_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Merlin_SSTU_RealPlume.cfg
@@ -6,6 +6,7 @@
         transformName = Merlin-1A-MainFXTransform
         scale = 0.543
 		offset = 0.63
+        setupEngine = false
     }
 	PLUME
     {
@@ -42,6 +43,7 @@
         transformName = Merlin-1C-ThrustTransform
         scale = 0.543
 		offset = 0.83
+        setupEngine = false
     }
 	PLUME
     {
@@ -79,6 +81,7 @@
 		transformName = Merlin-1D-ThrustTransform
 		scale = 0.543
 		offset = 0.83
+        setupEngine = false
 	}
 	PLUME
     {
@@ -115,6 +118,7 @@
         transformName = Merlin-1CV-ThrustTransform
         scale = 1.42
 		offset = 3.45
+        setupEngine = false
     }
 	PLUME
     {
@@ -154,8 +158,4 @@
         scale = 1.42
 		offset = 3.45
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Kerolox_Upper2
-	}
 }

--- a/GameData/ROEngines/RealPlume/Merlin_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Merlin_SSTU_RealPlume.cfg
@@ -1,96 +1,161 @@
 @PART[ROE-Merlin1A]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    PLUME
+    PLUME_TEMPLATE
     {
-        name = Kerolox-Lower
+        name = Kerolox_LowerFlame
         transformName = Merlin-1A-MainFXTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,0.6
-        plumePosition = 0,0,0.7
-        fixedScale = 0.6
-        energy = 0.5
-        speed = 0.7
+        scale = 0.543
+		offset = 0.63
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Kerolox-Lower
-	}
+	PLUME
+    {
+        name = Kerolox-Exhaust
+        transformName = Merlin-1A-MainFXTransform
+        localPosition = 0.44, 0.0, 0.15
+        fixedScale = 1.5
+    }
+}
+@PART[ROE-Merlin1A]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox_LowerFlame
+        {
+            |_ = CombinedPlume
+        }
+        @Kerolox-Exhaust
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEnginesRF]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 
 @PART[ROE-Merlin1C]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    PLUME
+    PLUME_TEMPLATE
     {
-        name = Kerolox-Lower
+        name = Kerolox_LowerFlame
         transformName = Merlin-1C-ThrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,0.96
-        plumePosition = 0,0,0.9
-        fixedScale = 0.7
-        energy = 0.75
-        speed = 1
+        scale = 0.543
+		offset = 0.83
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Kerolox-Lower
-	}
+	PLUME
+    {
+        name = Kerolox-Exhaust
+        transformName = Merlin-1C-ThrustTransform
+        localPosition = 0.58, 0.0, 0.2
+		localRotation = 0,9,0
+        fixedScale = 1.5
+    }
+}
+@PART[ROE-Merlin1C]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox_LowerFlame
+        {
+            |_ = CombinedPlume
+        }
+        @Kerolox-Exhaust
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEnginesRF]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 
 @PART[ROE-Merlin1D]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    PLUME
-    {
-        name = Kerolox-Lower
-        transformName = Merlin-1D-ThrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,0.9
-        plumePosition = 0,0,0.85
-        fixedScale = 0.75
-        energy = 0.85
-        speed = 1
-    }
-	@MODULE[ModuleEngines*]
+    PLUME_TEMPLATE
 	{
-        %powerEffectName = Kerolox-Lower
+		name = Kerolox_LowerFlame
+		transformName = Merlin-1D-ThrustTransform
+		scale = 0.543
+		offset = 0.83
 	}
+	PLUME
+    {
+        name = Kerolox-Exhaust
+        transformName = Merlin-1D-ThrustTransform
+        localPosition = 0.48, 0.0, 0.0
+        fixedScale = 2
+    }
+}
+@PART[ROE-Merlin1D]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox_LowerFlame
+        {
+            |_ = CombinedPlume
+        }
+        @Kerolox-Exhaust
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEnginesRF]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 
 @PART[ROE-Merlin1CV]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    PLUME
+    PLUME_TEMPLATE
     {
-        name = Kerolox-Upper
+        name = Kerolox_Upper2
         transformName = Merlin-1CV-ThrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,3.0
-        plumePosition = 0,0,3.5
-        flareScale = 1.75
-        fixedScale = 1.5
-        energy = 0.75
-        speed = 1
+        scale = 1.42
+		offset = 3.45
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Kerolox-Upper
-	}
+	PLUME
+    {
+        name = Kerolox-Exhaust
+        transformName = Merlin-1CV-ThrustTransform
+        localPosition = 0.8, 0.0, 0.55
+		localRotation = 0,17,0
+        fixedScale = 1.5
+    }
+	
+}
+@PART[ROE-Merlin1CV]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox_Upper2
+        {
+            |_ = CombinedPlume
+        }
+        @Kerolox-Exhaust
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEnginesRF]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 
 @PART[ROE-Merlin1DV]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    PLUME
+    PLUME_TEMPLATE
     {
-        name = Kerolox-Upper
+        name = Kerolox_Upper2
         transformName = Merlin-1DV-ThrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,3.0
-        plumePosition = 0,0,3.5
-        flareScale = 1.75
-        fixedScale = 1.5
-        energy = 0.75
-        speed = 1
+        scale = 1.42
+		offset = 3.45
     }
 	@MODULE[ModuleEngines*]
 	{
-        %powerEffectName = Kerolox-Upper
+        %powerEffectName = Kerolox_Upper2
 	}
 }

--- a/GameData/ROEngines/RealPlume/NK33_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/NK33_RE_RealPlume.cfg
@@ -15,7 +15,7 @@
 		transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.2
         flareScale =    1.0
-        plumePosition = 0.0, 0.0, -0.2
+        plumePosition = 0.0, 0.0, 0.2
         plumeScale =    1.0
 		smokePosition =	0.0, 0.0, 0.0
 		smokeScale =	0.75

--- a/GameData/ROEngines/RealPlume/NK33_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/NK33_RE_RealPlume.cfg
@@ -2,28 +2,28 @@
 {
     @MODULE[ModuleEngineConfigs]
     {
-		%type = ModuleEnginesRF
+        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower
         }
     }
-	
-	PLUME
+    
+    PLUME
     {
         name = Kerolox-Lower
-		transformName = thrustTransform
+        transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.2
         flareScale =    1.0
         plumePosition = 0.0, 0.0, 0.2
         plumeScale =    1.0
-		smokePosition =	0.0, 0.0, 0.0
-		smokeScale =	0.75
-		
-        fixedScale =	1.0
-		energy =		1.0
-        speed =			1.0
-        emissionMult =	0.5
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale =    0.75
+        
+        fixedScale =    1.0
+        energy =        1.0
+        speed =         1.0
+        emissionMult =  0.5
     }
 }
 

--- a/GameData/ROEngines/RealPlume/NK43_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/NK43_RE_RealPlume.cfg
@@ -14,8 +14,8 @@
         name = Kerolox-Upper
 		transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.75
-        flareScale =    1.75
-        plumePosition = 0.0, 0.0, -0.25
+        flareScale =    1.6
+        plumePosition = 0.0, 0.0, 0.15
         plumeScale =    1.25
 		smokePosition =	0.0, 0.0, 0.0
 		smokeScale =	1.25

--- a/GameData/ROEngines/RealPlume/NK43_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/NK43_RE_RealPlume.cfg
@@ -2,28 +2,28 @@
 {
     @MODULE[ModuleEngineConfigs]
     {
-		%type = ModuleEnginesRF
+        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Upper
         }
     }
-	
-	PLUME
+    
+    PLUME
     {
         name = Kerolox-Upper
-		transformName = thrustTransform
+        transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.75
         flareScale =    1.6
         plumePosition = 0.0, 0.0, 0.15
         plumeScale =    1.25
-		smokePosition =	0.0, 0.0, 0.0
-		smokeScale =	1.25
-		
-        fixedScale =	1.0
-		energy =		1.0
-        speed =			1.0
-        emissionMult =	0.5
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale =    1.25
+        
+        fixedScale =    1.0
+        energy =        1.0
+        speed =         1.0
+        emissionMult =  0.5
     }
 }
 

--- a/GameData/ROEngines/RealPlume/ORM65_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/ORM65_RealPlume.cfg
@@ -1,10 +1,10 @@
 @PART[ROE-ORM65]:NEEDS[RealPlume,SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesFX
-		%powerEffectName = Hypergolic-Lower
-	}
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesFX
+        %powerEffectName = Hypergolic-Lower
+    }
     PLUME
     {
         name = Hypergolic-Lower

--- a/GameData/ROEngines/RealPlume/PLE_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/PLE_NicheParts_RealPlume.cfg
@@ -4,27 +4,22 @@
     {
         name = Hypergolic-OMS-White
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, -0.77
-        flareScale =    0.08
-        plumePosition = 0.0, 0.0, 0.0
+        flarePosition = 0.0, 0.0, -0.84
+        flareScale =    0.03
+        plumePosition = 0.0, 0.0, 0.04
         plumeScale =    0.08
         fixedScale =	0.08
 		energy = 		1.0
         speed = 		1.0
         emissionMult = 	0.5
     }
-	PLUME
+	PLUME_TEMPLATE
     {
-        name = Hypergolic-OMS-Red
+        name = Hypergolic_UpperRed
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.5
-        flareScale =    0.08
-        plumePosition = 0.0, 0.0, 0.5
-        plumeScale =    0.08
-        fixedScale =	0.08
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	0.5
+        scale = 0.046
+		offset = 0.0
+		setupEngine = false
     }
 }
 
@@ -39,27 +34,27 @@
 
         @CONFIG[MMH+NTO]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
 
         @CONFIG[MMH+MON3]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
 
         @CONFIG[UDMH+NTO]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
 
         @CONFIG[Aerozine50+NTO]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
 
         @CONFIG[Cavea-B]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
     }
 }

--- a/GameData/ROEngines/RealPlume/PLE_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/PLE_NicheParts_RealPlume.cfg
@@ -3,23 +3,23 @@
     PLUME
     {
         name = Hypergolic-OMS-White
-		transformName = thrustTransform
+        transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.84
         flareScale =    0.03
         plumePosition = 0.0, 0.0, 0.04
         plumeScale =    0.08
-        fixedScale =	0.08
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	0.5
+        fixedScale =    0.08
+        energy =        1.0
+        speed =         1.0
+        emissionMult =  0.5
     }
-	PLUME_TEMPLATE
+    PLUME_TEMPLATE
     {
         name = Hypergolic_UpperRed
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.046
-		offset = 0.0
-		setupEngine = false
+        offset = 0.0
+        setupEngine = false
     }
 }
 

--- a/GameData/ROEngines/RealPlume/R40B_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/R40B_NicheParts_RealPlume.cfg
@@ -1,24 +1,18 @@
 @PART[ROE-R40B]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs],*
+	//@MODULE[ModuleEngineConfigs],*
+    //{
+	//	%type = ModuleEnginesRF
+    //    @CONFIG,*
+    //    {
+    //        %powerEffectName = Hypergolic-OMS-White
+    //    }
+	//}
+    PLUME_TEMPLATE
     {
-		%type = ModuleEnginesRF
-        @CONFIG,*
-        {
-            %powerEffectName = Hypergolic-OMS-White
-        }
-	}
-    PLUME
-    {
-        name = Hypergolic-OMS-White
+        name = Hypergolic_UpperRed
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, -0.5
-        flareScale =    0.35
-        plumePosition = 0.0, 0.0, -0.5
-        plumeScale =    0.35
-        fixedScale =	0.35
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        scale = 0.2273
+		offset = 0.05
     }
 }

--- a/GameData/ROEngines/RealPlume/R40B_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/R40B_NicheParts_RealPlume.cfg
@@ -1,18 +1,10 @@
 @PART[ROE-R40B]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	//@MODULE[ModuleEngineConfigs],*
-    //{
-	//	%type = ModuleEnginesRF
-    //    @CONFIG,*
-    //    {
-    //        %powerEffectName = Hypergolic-OMS-White
-    //    }
-	//}
     PLUME_TEMPLATE
     {
         name = Hypergolic_UpperRed
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.2273
-		offset = 0.05
+        offset = 0.05
     }
 }

--- a/GameData/ROEngines/RealPlume/R42_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/R42_NicheParts_RealPlume.cfg
@@ -1,18 +1,10 @@
 @PART[ROE-R42]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    //@MODULE[ModuleEngineConfigs],*
-    //{
-	//	%type = ModuleEnginesRF
-    //    @CONFIG,*
-    //    {
-    //        %powerEffectName = Hypergolic-OMS-White
-    //    }
-	//}
     PLUME_TEMPLATE
     {
         name = Hypergolic_UpperRed
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.2273
-		offset = 0.1
+        offset = 0.1
     }
 }

--- a/GameData/ROEngines/RealPlume/R42_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/R42_NicheParts_RealPlume.cfg
@@ -1,24 +1,18 @@
 @PART[ROE-R42]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    @MODULE[ModuleEngineConfigs],*
+    //@MODULE[ModuleEngineConfigs],*
+    //{
+	//	%type = ModuleEnginesRF
+    //    @CONFIG,*
+    //    {
+    //        %powerEffectName = Hypergolic-OMS-White
+    //    }
+	//}
+    PLUME_TEMPLATE
     {
-		%type = ModuleEnginesRF
-        @CONFIG,*
-        {
-            %powerEffectName = Hypergolic-OMS-White
-        }
-	}
-    PLUME
-    {
-        name = Hypergolic-OMS-White
+        name = Hypergolic_UpperRed
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, -0.1
-        flareScale =    0.6
-        plumePosition = 0.0, 0.0, -0.1
-        plumeScale =    0.6
-        fixedScale =	0.6
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        scale = 0.2273
+		offset = 0.1
     }
 }

--- a/GameData/ROEngines/RealPlume/RD0105_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD0105_RE_RealPlume.cfg
@@ -1,36 +1,32 @@
 @PART[ROE-RD0105]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
+	PLUME_TEMPLATE
     {
-        name = Kerolox-Upper
+        name = Kerolox_Upper2
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.45
-        flareScale =    0.65
-		flareEnergy =	1.0
-        plumePosition = 0.0, 0.0, 0.35
-        plumeScale =    0.35
-        fixedScale =	0.35
-		energy =		0.25
-        speed =			1.0
-        emissionMult =	1.0
+        scale = 0.45
+		offset = 0.29
     }
 	PLUME
     {
-        name = Kerolox-Exhaust
-        transformName = vernierTransform
-        localPosition = 0.0, 0.0, 0.02
-        fixedScale = 1.5
+        name = Kerolox_VernierEagle
+		transformName = vernierTransform
+        localPosition = 0,0,0.04
+        plumeScale = 0.14
+		energy = 1
+        speed = 1
+        emissionMult = 1
     }
 }
 @PART[ROE-RD0105]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
 {
     @EFFECTS
     {
-        @Kerolox-Upper
+        @Kerolox_Upper2
         {
             |_ = CombinedPlume
         }
-        @Kerolox-Exhaust
+        @Kerolox_VernierEagle
         {
             |_ = CombinedPlume
         }

--- a/GameData/ROEngines/RealPlume/RD0105_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD0105_RE_RealPlume.cfg
@@ -6,6 +6,7 @@
 		transformName = thrustTransform
         scale = 0.45
 		offset = 0.29
+        setupEngine = false
     }
 	PLUME
     {

--- a/GameData/ROEngines/RealPlume/RD0105_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD0105_RE_RealPlume.cfg
@@ -1,20 +1,20 @@
 @PART[ROE-RD0105]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME_TEMPLATE
+    PLUME_TEMPLATE
     {
         name = Kerolox_Upper2
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.45
-		offset = 0.29
+        offset = 0.29
         setupEngine = false
     }
-	PLUME
+    PLUME
     {
         name = Kerolox_VernierEagle
-		transformName = vernierTransform
+        transformName = vernierTransform
         localPosition = 0,0,0.04
         plumeScale = 0.14
-		energy = 1
+        energy = 1
         speed = 1
         emissionMult = 1
     }

--- a/GameData/ROEngines/RealPlume/RD0110_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD0110_SSTU_RealPlume.cfg
@@ -5,8 +5,8 @@
         name = Kerolox_Upper2
         transformName = RD-0110-MainFXTransform
         scale = 0.45
-		offset = 0.29
-		setupEngine = false
+        offset = 0.29
+        setupEngine = false
     }
     PLUME
     {
@@ -14,7 +14,7 @@
         transformName = RD-0110-VernierFXTransform
         localPosition = 0,0,0.05
         plumeScale = 0.25
-		energy = 1
+        energy = 1
         speed = 1
         emissionMult = 1
     }

--- a/GameData/ROEngines/RealPlume/RD0110_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD0110_SSTU_RealPlume.cfg
@@ -6,6 +6,7 @@
         transformName = RD-0110-MainFXTransform
         scale = 0.45
 		offset = 0.29
+		setupEngine = false
     }
     PLUME
     {

--- a/GameData/ROEngines/RealPlume/RD0110_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD0110_SSTU_RealPlume.cfg
@@ -1,36 +1,32 @@
 @PART[ROE-RD0110]:NEEDS[RealPlume]:BEFORE[RealPlume]
 {
-    PLUME
+    PLUME_TEMPLATE
     {
-        name = Kerolox-Upper
+        name = Kerolox_Upper2
         transformName = RD-0110-MainFXTransform
-        localRotation = 0,0,0
-        plumePosition = 0.0, 0.0, 0.4
-        plumeScale = 0.4
-        flarePosition = 0.0, 0.0, 0.3
-        flareScale = 0.6
-		smokePosition = 0.0, 0.0, 0.05
-        smokeScale = 0.125
-        energy = 0.7
-        speed = 1
+        scale = 0.45
+		offset = 0.29
     }
     PLUME
     {
-        name = Kerolox-Exhaust
+        name = Kerolox_VernierEagle
         transformName = RD-0110-VernierFXTransform
-        localPosition = 0.0, 0.0, 0.1
-        fixedScale = 3.5
+        localPosition = 0,0,0.05
+        plumeScale = 0.25
+		energy = 1
+        speed = 1
+        emissionMult = 1
     }
 }
 @PART[ROE-RD0110]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
 {
     @EFFECTS
     {
-        @Kerolox-Upper
+        @Kerolox_Upper2
         {
             |_ = CombinedPlume
         }
-        @Kerolox-Exhaust
+        @Kerolox_VernierEagle
         {
             |_ = CombinedPlume
         }

--- a/GameData/ROEngines/RealPlume/RD100_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD100_RE_RealPlume.cfg
@@ -10,8 +10,8 @@
         transformName = thrustTransform
         plumePosition = 0.0, 0.0, 0.0
         plumeScale = 0.35
-        flarePosition = 0.0, 0.0, 0.8
-        flareScale = 0.425
+        flarePosition = 0.0, 0.0, 0.5
+        flareScale = 0.35
         smokePosition = 0.0, 0.0, 0.0
         smokeScale = 1.0
         localRotation = 0.0, 0.0, 0.0

--- a/GameData/ROEngines/RealPlume/RD107NV_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD107NV_SSTU_RealPlume.cfg
@@ -11,8 +11,8 @@
         energy = 1.5
         speed = 1.5
     }
-	@MODULE[ModuleEngines*]
-	{
+    @MODULE[ModuleEngines*]
+    {
         %powerEffectName = Kerolox-Lower
-	}
+    }
 }

--- a/GameData/ROEngines/RealPlume/RD107_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD107_SSTU_RealPlume.cfg
@@ -5,8 +5,8 @@
         name = Kerolox_LowerFlame
         transformName = RD-107A-MainFXTransform
         scale = 0.389
-		offset = 0.42
-		setupEngine = false
+        offset = 0.42
+        setupEngine = false
     }
     PLUME
     {

--- a/GameData/ROEngines/RealPlume/RD107_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD107_SSTU_RealPlume.cfg
@@ -1,24 +1,21 @@
 @PART[ROE-RD107]:NEEDS[RealPlume]:BEFORE[RealPlume]
 {
-    PLUME
+    PLUME_TEMPLATE
     {
-        name = Kerolox-Lower
+        name = Kerolox_LowerFlame
         transformName = RD-107A-MainFXTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,0.4
-        plumePosition = 0,0,0.5
-        fixedScale = 0.6
-        energy = 1.5
-        speed = 1.5
+        scale = 0.389
+		offset = 0.42
+		setupEngine = false
     }
     PLUME
     {
-        name = Kerolox-Upper
+        name = Kerolox_VernierEagle
         transformName = RD-107A-VernierFXTransform
         localRotation = 0,0,0
         localPosition = 0,0,0.26
         plumePosition = 0,0,0.3
-        fixedScale = 0.26
+        fixedScale = 0.31
         energy = 0.4
         speed = 1.2
     }
@@ -27,11 +24,11 @@
 {
     @EFFECTS
     {
-        @Kerolox-Lower
+        @Kerolox_LowerFlame
         {
             |_ = CombinedPlume
         }
-        @Kerolox-Upper
+        @Kerolox_VernierEagle
         {
             |_ = CombinedPlume
         }

--- a/GameData/ROEngines/RealPlume/RD108_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD108_SSTU_RealPlume.cfg
@@ -1,24 +1,21 @@
 @PART[ROE-RD108]:NEEDS[RealPlume]:BEFORE[RealPlume]
 {
-    PLUME
+    PLUME_TEMPLATE
     {
-        name = Kerolox-Lower
+        name = Kerolox_LowerFlame
         transformName = RD-108A-MainFXTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,0.4
-        plumePosition = 0,0,0.5
-        fixedScale = 0.6
-        energy = 1.5
-        speed = 1.5
+        scale = 0.389
+		offset = 0.42
+		setupEngine = false
     }
     PLUME
     {
-        name = Kerolox-Upper
+        name = Kerolox_VernierEagle
         transformName = RD-108A-VernierFXTransform
         localRotation = 0,0,0
         localPosition = 0,0,0.26
         plumePosition = 0,0,0.3
-        fixedScale = 0.26
+        fixedScale = 0.31
         energy = 0.4
         speed = 1.2
     }
@@ -27,11 +24,11 @@
 {
     @EFFECTS
     {
-        @Kerolox-Lower
+        @Kerolox_LowerFlame
         {
             |_ = CombinedPlume
         }
-        @Kerolox-Upper
+        @Kerolox_VernierEagle
         {
             |_ = CombinedPlume
         }

--- a/GameData/ROEngines/RealPlume/RD108_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD108_SSTU_RealPlume.cfg
@@ -5,8 +5,8 @@
         name = Kerolox_LowerFlame
         transformName = RD-108A-MainFXTransform
         scale = 0.389
-		offset = 0.42
-		setupEngine = false
+        offset = 0.42
+        setupEngine = false
     }
     PLUME
     {

--- a/GameData/ROEngines/RealPlume/RD170_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD170_SSTU_RealPlume.cfg
@@ -4,24 +4,17 @@
 
 @PART[ROE-RD170]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    PLUME
+    PLUME_TEMPLATE
     {
-        name = Kerolox-Lower
+        name = Kerolox_LowerFlame
         transformName = RD-171-ThrustTransform
-        plumePosition = 0.0, 0.0, 1.7
-        plumeScale = 0.85
-        flarePosition = 0.0, 0.0, 1.7
-        flareScale = 1.4
-        smokePosition = 0.0, 0.0, 1.7
-        smokeScale = 0.85
-        energy = 1.0
-        speed = 1.0
-        emissionMult = 0.5
+        scale = 0.93
+		offset = 1.45
     }
 
     @MODULE[ModuleEngines*]
     {
-        %powerEffectName = Kerolox-Lower
+        %powerEffectName = Kerolox_LowerFlame
         !runningEffectName = NULL
         !fxOffset = NULL
     }
@@ -30,7 +23,7 @@
     {
         @CONFIG,*
         {
-            %powerEffectName = Kerolox-Lower
+            %powerEffectName = Kerolox_LowerFlame
         }
     }
 }

--- a/GameData/ROEngines/RealPlume/RD170_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD170_SSTU_RealPlume.cfg
@@ -9,7 +9,7 @@
         name = Kerolox_LowerFlame
         transformName = RD-171-ThrustTransform
         scale = 0.93
-		offset = 1.45
+        offset = 1.45
     }
 
     @MODULE[ModuleEngines*]

--- a/GameData/ROEngines/RealPlume/RD180_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD180_SSTU_RealPlume.cfg
@@ -9,7 +9,7 @@
         name = Kerolox_LowerFlame
         transformName = RD-180-ThrustTransform
         scale = 0.93
-		offset = 1.45
+        offset = 1.45
     }
 
     @MODULE[ModuleEngines*]

--- a/GameData/ROEngines/RealPlume/RD180_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD180_SSTU_RealPlume.cfg
@@ -4,26 +4,17 @@
 
 @PART[ROE-RD180]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    PLUME
+    PLUME_TEMPLATE
     {
-        name = Kerolox-Lower
+        name = Kerolox_LowerFlame
         transformName = RD-180-ThrustTransform
-        plumePosition = 0.0, 0.0, 1.4
-        plumeScale = 0.85
-        flarePosition = 0.0, 0.0, 1.4
-        flareScale = 1.25
-        smokePosition = 0.0, 0.0, 0.0
-        smokeScale = 0.85
-        localRotation = 0.0, 0.0, 0.0
-        fixedScale = 1.0
-        energy = 1.0
-        speed = 1.0
-        emissionMult = 0.5
+        scale = 0.93
+		offset = 1.45
     }
 
     @MODULE[ModuleEngines*]
     {
-        %powerEffectName = Kerolox-Lower
+        %powerEffectName = Kerolox_LowerFlame
         !runningEffectName = NULL
         !fxOffset = NULL
     }
@@ -32,7 +23,7 @@
     {
         @CONFIG,*
         {
-            %powerEffectName = Kerolox-Lower
+            %powerEffectName = Kerolox_LowerFlame
         }
     }
 }

--- a/GameData/ROEngines/RealPlume/RD191_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD191_SSTU_RealPlume.cfg
@@ -4,12 +4,12 @@
 
 @PART[ROE-RD191]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME_TEMPLATE
+    PLUME_TEMPLATE
     {
         name = Kerolox_LowerFlame
         transformName = RD-181-ThrustTransform
         scale = 0.93
-		offset = 1.45
+        offset = 1.45
     }
 
     @MODULE[ModuleEngines*]

--- a/GameData/ROEngines/RealPlume/RD191_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD191_SSTU_RealPlume.cfg
@@ -4,26 +4,17 @@
 
 @PART[ROE-RD191]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    PLUME
+	PLUME_TEMPLATE
     {
-        name = Kerolox-Lower
+        name = Kerolox_LowerFlame
         transformName = RD-181-ThrustTransform
-        plumePosition = 0.0, 0.0, 1.5
-        plumeScale = 0.85
-        flarePosition = 0.0, 0.0, 1.6
-        flareScale = 1.2
-        smokePosition = 0.0, 0.0, 0.0
-        smokeScale = 0.85
-        localRotation = 0.0, 0.0, 0.0
-        fixedScale = 1.0
-        energy = 1.0
-        speed = 1.0
-        emissionMult = 0.5
+        scale = 0.93
+		offset = 1.45
     }
 
     @MODULE[ModuleEngines*]
     {
-        %powerEffectName = Kerolox-Lower
+        %powerEffectName = Kerolox_LowerFlame
         !runningEffectName = NULL
         !fxOffset = NULL
     }
@@ -32,7 +23,7 @@
     {
         @CONFIG,*
         {
-            %powerEffectName = Kerolox-Lower
+            %powerEffectName = Kerolox_LowerFlame
         }
     }
 }

--- a/GameData/ROEngines/RealPlume/RD275_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD275_RE_RealPlume.cfg
@@ -4,29 +4,12 @@
 
 @PART[ROE-RD275]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    PLUME
+    PLUME_TEMPLATE
     {
         name = Hypergolic_LowerOrangeShock
         transformName = thrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,0.39
-        fixedScale = 1.56
-        energy = 1
-        speed = 1
-        emissionMult = 0.75
-        alphaMult = 1
-
-        flarePosition = 0,0,-0.39
-        flareScale = 0.39
-
-        plumePosition = 0,0,0.39
-        plumeScale = 1.95
-
-        fumePosition = 0,0,0.78
-        fumeScale = 2.34
-
-        blazePosition = 0,0,0
-        blazeScale = 1.95
+        scale = 0.95
+		offset = 0
     }
 
     @MODULE[ModuleEngines*]

--- a/GameData/ROEngines/RealPlume/RD275_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD275_RE_RealPlume.cfg
@@ -6,24 +6,32 @@
 {
     PLUME
     {
-        name = Hypergolic-Lower
+        name = Hypergolic_LowerOrangeShock
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 0.125
-        plumeScale = 1.85
-        flarePosition = 0.0, 0.0, 0.0
-        flareScale = 1.75
-        smokePosition = 0.0, 0.0, 0.0
-        smokeScale = 1.0
-        localRotation = 0.0, 0.0, 0.0
-        fixedScale = 1.0
-        energy = 1.0
-        speed = 1.0
-        emissionMult = 1.0
+        localRotation = 0,0,0
+        localPosition = 0,0,0.39
+        fixedScale = 1.56
+        energy = 1
+        speed = 1
+        emissionMult = 0.75
+        alphaMult = 1
+
+        flarePosition = 0,0,-0.39
+        flareScale = 0.39
+
+        plumePosition = 0,0,0.39
+        plumeScale = 1.95
+
+        fumePosition = 0,0,0.78
+        fumeScale = 2.34
+
+        blazePosition = 0,0,0
+        blazeScale = 1.95
     }
 
     @MODULE[ModuleEngines*]
     {
-        %powerEffectName = Hypergolic-Lower
+        %powerEffectName = Hypergolic_LowerOrangeShock
         !runningEffectName = DELETE
     }
 
@@ -31,7 +39,7 @@
     {
         @CONFIG,*
         {
-            %powerEffectName = Hypergolic-Lower
+            %powerEffectName = Hypergolic_LowerOrangeShock
         }
     }
 }

--- a/GameData/ROEngines/RealPlume/RD275_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD275_RE_RealPlume.cfg
@@ -9,7 +9,7 @@
         name = Hypergolic_LowerOrangeShock
         transformName = thrustTransform
         scale = 0.95
-		offset = 0
+        offset = 0
     }
 
     @MODULE[ModuleEngines*]

--- a/GameData/ROEngines/RealPlume/RD58_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD58_RE_RealPlume.cfg
@@ -1,29 +1,20 @@
 @PART[ROE-RD58]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    @MODULE[ModuleEngineConfigs]
-    {
-		%type = ModuleEnginesRF
-        @CONFIG,*
-        {
-            %powerEffectName = Kerolox-Upper
-        }
-    }
+    //@MODULE[ModuleEngineConfigs]
+    //{
+	//	%type = ModuleEnginesRF
+    //    @CONFIG,*
+    //    {
+    //        %powerEffectName = Kerolox-Upper
+    //    }
+    //}
 	
-	PLUME
+	PLUME_TEMPLATE
     {
-        name = Kerolox-Upper
+        name = Kerolox_Upper2
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.25
-        flareScale =    0.9
-        plumePosition = 0.0, 0.0, 0.3
-        plumeScale =    0.7
-		smokePosition =	0.0, 0.0, 0.0
-		smokeScale =	0.5
-		
-        fixedScale =	1.0
-		energy =		1.0
-        speed =			1.0
-        emissionMult =	1.0
+        scale = 0.75
+		offset = -0.1
     }
 }
 

--- a/GameData/ROEngines/RealPlume/RD58_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD58_RE_RealPlume.cfg
@@ -1,20 +1,11 @@
 @PART[ROE-RD58]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    //@MODULE[ModuleEngineConfigs]
-    //{
-	//	%type = ModuleEnginesRF
-    //    @CONFIG,*
-    //    {
-    //        %powerEffectName = Kerolox-Upper
-    //    }
-    //}
-	
-	PLUME_TEMPLATE
+    PLUME_TEMPLATE
     {
         name = Kerolox_Upper2
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.75
-		offset = -0.1
+        offset = -0.1
     }
 }
 

--- a/GameData/ROEngines/RealPlume/RD8_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD8_RE_RealPlume.cfg
@@ -2,17 +2,17 @@
 {
     @MODULE[ModuleEngineConfigs]
     {
-		%type = ModuleEnginesRF
+        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox_VernierEagle
         }
     }
-	
-	PLUME
+    
+    PLUME
     {
         name = Kerolox_VernierEagle
-		transformName = thrustTransform2
+        transformName = thrustTransform2
         localRotation = 0,0,0
         localPosition = 0,0,0.0
         fixedScale = 0.6

--- a/GameData/ROEngines/RealPlume/RD8_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD8_RE_RealPlume.cfg
@@ -5,25 +5,19 @@
 		%type = ModuleEnginesRF
         @CONFIG,*
         {
-            %powerEffectName = Kerolox-Vernier
+            %powerEffectName = Kerolox_VernierEagle
         }
     }
 	
 	PLUME
     {
-        name = Kerolox-Vernier
+        name = Kerolox_VernierEagle
 		transformName = thrustTransform2
-        //flarePosition = 0.0, 0.0, 0.25
-        //flareScale =    0.9
-        plumePosition = 0.0, 0.0, -0.3
-        plumeScale =    5.0
-		//smokePosition =	0.0, 0.0, 0.0
-		//smokeScale =	0.5
-		
-        fixedScale =	1.0
-		energy =		0.5
-        speed =			1.0
-        emissionMult =	1.0
+        localRotation = 0,0,0
+        localPosition = 0,0,0.0
+        fixedScale = 0.6
+        energy = 1
+        speed = 1.5
     }
 }
 

--- a/GameData/ROEngines/RealPlume/RL10A3_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RL10A3_SSTU_RealPlume.cfg
@@ -1,10 +1,10 @@
 @PART[ROE-RL10A3]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		!runningEffectName = DELETE
-	}
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        !runningEffectName = DELETE
+    }
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
@@ -18,7 +18,7 @@
         name = Hydrolox-Upper
         transformName = RL10A-3-ThrustTransform
         localRotation = 0,0,0
-		plumePosition = 0,0,1.6
+        plumePosition = 0,0,1.6
         plumeScale = 1.3
         flarePosition = 0,0,1.5
         flareScale = 1.3

--- a/GameData/ROEngines/RealPlume/RL10A4_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RL10A4_SSTU_RealPlume.cfg
@@ -5,15 +5,15 @@
         name = Hydrolox-Upper
         transformName = RL10A-4-ThrustTransform
         localRotation = 0,0,0
-		plumePosition = 0,0,1.75
+        plumePosition = 0,0,1.75
         plumeScale = 1.2
         flarePosition = 0,0,1.75
         flareScale = 1.4
         energy = 1
         speed = 1.2
     }
-	@MODULE[ModuleEngines*]
-	{
+    @MODULE[ModuleEngines*]
+    {
         %powerEffectName = Hydrolox-Upper
-	}
+    }
 }

--- a/GameData/ROEngines/RealPlume/RL10A5_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RL10A5_SSTU_RealPlume.cfg
@@ -5,10 +5,10 @@
         name = Hydrolox-Upper
         transformName = RL10A-5-ThrustTransform
         localRotation = 0,0,0
-		plumePosition = 0,0,1.1
+		plumePosition = 0,0,1.5
         plumeScale = 0.5
         flarePosition = 0,0,1
-        flareScale = 0.5
+        flareScale = 0.3
         energy = 1
         speed = 1.2
     }

--- a/GameData/ROEngines/RealPlume/RL10A5_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RL10A5_SSTU_RealPlume.cfg
@@ -5,15 +5,15 @@
         name = Hydrolox-Upper
         transformName = RL10A-5-ThrustTransform
         localRotation = 0,0,0
-		plumePosition = 0,0,1.5
+        plumePosition = 0,0,1.5
         plumeScale = 0.5
         flarePosition = 0,0,1
         flareScale = 0.3
         energy = 1
         speed = 1.2
     }
-	@MODULE[ModuleEngines*]
-	{
+    @MODULE[ModuleEngines*]
+    {
         %powerEffectName = Hydrolox-Upper
-	}
+    }
 }

--- a/GameData/ROEngines/RealPlume/RL10B2_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RL10B2_SSTU_RealPlume.cfg
@@ -1,10 +1,10 @@
 @PART[ROE-RL10B2]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		!runningEffectName = DELETE
-	}
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        !runningEffectName = DELETE
+    }
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
@@ -18,7 +18,7 @@
         name = Hydrolox-Upper
         transformName = RL10B-2-ThrustTransform
         localRotation = 0,0,0
-		plumePosition = 0,0,2.9
+        plumePosition = 0,0,2.9
         plumeScale = 2.5
         flarePosition = 0,0,2.8
         flareScale = 2.5

--- a/GameData/ROEngines/RealPlume/RL10C_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RL10C_SSTU_RealPlume.cfg
@@ -5,15 +5,15 @@
         name = Hydrolox-Upper
         transformName = RL10B-2-ThrustTransform
         localRotation = 0,0,0
-		plumePosition = 0,0,1.75
+        plumePosition = 0,0,1.75
         plumeScale = 1.2
         flarePosition = 0,0,1.75
         flareScale = 1.4
         energy = 1
         speed = 1.2
     }
-	@MODULE[ModuleEngines*]
-	{
+    @MODULE[ModuleEngines*]
+    {
         %powerEffectName = Hydrolox-Upper
-	}
+    }
 }

--- a/GameData/ROEngines/RealPlume/RS25_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RS25_SSTU_RealPlume.cfg
@@ -1,26 +1,26 @@
 @PART[ROE-RS25]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesFX
-		%powerEffectName = Cryogenic_LowerSSME_CE
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesFX
+        %powerEffectName = Cryogenic_LowerSSME_CE
     }
     PLUME
     {
         name = Cryogenic_LowerSSME_CE
         transformName = RS-25-ThrustTransform
         localRotation = 0,0,0
-		shockPosition = 0,0,2.4
-		shockScale = 0.87
+        shockPosition = 0,0,2.4
+        shockScale = 0.87
 
-		plumePosition = 0,0,2.1
-		plumeScale = 2.6
+        plumePosition = 0,0,2.1
+        plumeScale = 2.6
 
-		plume2Scale = 1.3
-		
-		corePosition = 0,0,0
-		coreScale = 1
-		
+        plume2Scale = 1.3
+        
+        corePosition = 0,0,0
+        coreScale = 1
+        
         energy = 1.0
         speed = 1
     }

--- a/GameData/ROEngines/RealPlume/RS68_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RS68_SSTU_RealPlume.cfg
@@ -7,13 +7,13 @@
         localRotation = 0,0,0
         localPosition = 0,0,2.3
 		
-		flarePosition = 0,0,1.3
-		fixedScale = 1.1
+		flarePosition = 0,0,1.4
+		fixedScale = 0.9
 		
 		corePosition = 0,0,2.3
 		coreScale = 1.45
 		
-        plumePosition = 0, 0, 2.3
+        plumePosition = 0, 0, 2.1
 		plumeScale = 1.45
         fixedScale = 3
         energy = 1
@@ -21,30 +21,29 @@
     }
     PLUME
     {
-        name = Hydrolox-Upper
+        name = Cryogenic_VernierOrange
         transformName = RS-68-RollExhaust
         localRotation = 0, 0, 0
-        flarePosition = 0,0.015,0.71
-		plumePosition = 0,0,1.1
-        fixedScale = 0.3
+		plumePosition = 0,0,-0.1
+        fixedScale = 1.5
         energy = 1
         speed = 0.5
     }
 }
 
-@PART[ROE-RS68]:AFTER[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
-{
-	@EFFECTS
-	{
-		@CombinedPlume:HAS[#plumeIdentifier[Hydrolox-Upper]]
-		{
-			@MODEL_MULTI_SHURIKEN_PERSIST:HAS[#name[Hydrolox-Upper-plume_grey]]
-			{
-				@localPosition = 0,0,0.23
-			}
-		}
-	}
-}
+//@PART[ROE-RS68]:AFTER[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
+//{
+//	@EFFECTS
+//	{
+//		@CombinedPlume:HAS[#plumeIdentifier[Hydrolox-Upper]]
+//		{
+//			@MODEL_MULTI_SHURIKEN_PERSIST:HAS[#name[Hydrolox-Upper-plume_grey]]
+//			{
+//				@localPosition = 0,0,0.23
+//			}
+//		}
+//	}
+//}
 @PART[ROE-RS68]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
 {
     @EFFECTS
@@ -53,7 +52,7 @@
         {
             |_ = CombinedPlume
         }
-        @Hydrolox-Upper
+        @Cryogenic_VernierOrange
         {
             |_ = CombinedPlume
         }

--- a/GameData/ROEngines/RealPlume/RS68_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RS68_SSTU_RealPlume.cfg
@@ -6,15 +6,15 @@
         transformName = RS-68-MainFXTransform
         localRotation = 0,0,0
         localPosition = 0,0,2.3
-		
-		flarePosition = 0,0,1.4
-		fixedScale = 0.9
-		
-		corePosition = 0,0,2.3
-		coreScale = 1.45
-		
+        
+        flarePosition = 0,0,1.4
+        fixedScale = 0.9
+        
+        corePosition = 0,0,2.3
+        coreScale = 1.45
+        
         plumePosition = 0, 0, 2.1
-		plumeScale = 1.45
+        plumeScale = 1.45
         fixedScale = 3
         energy = 1
         speed = 1
@@ -24,26 +24,13 @@
         name = Cryogenic_VernierOrange
         transformName = RS-68-RollExhaust
         localRotation = 0, 0, 0
-		plumePosition = 0,0,-0.1
+        plumePosition = 0,0,-0.1
         fixedScale = 1.5
         energy = 1
         speed = 0.5
     }
 }
 
-//@PART[ROE-RS68]:AFTER[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
-//{
-//	@EFFECTS
-//	{
-//		@CombinedPlume:HAS[#plumeIdentifier[Hydrolox-Upper]]
-//		{
-//			@MODEL_MULTI_SHURIKEN_PERSIST:HAS[#name[Hydrolox-Upper-plume_grey]]
-//			{
-//				@localPosition = 0,0,0.23
-//			}
-//		}
-//	}
-//}
 @PART[ROE-RS68]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
 {
     @EFFECTS

--- a/GameData/ROEngines/RealPlume/RutherfordVac_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RutherfordVac_NicheParts_RealPlume.cfg
@@ -1,18 +1,10 @@
 @PART[ROE-RutherfordVac]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	//@MODULE[ModuleEngineConfigs],*
-    //{
-	//	%type = ModuleEnginesRF
-    //    @CONFIG,*
-    //    {
-    //        %powerEffectName = Kerolox-Upper
-    //    }
-	//}
     PLUME_TEMPLATE
     {
         name = Kerolox_Upper2
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.323
-		offset = 0
+        offset = 0
     }
 }

--- a/GameData/ROEngines/RealPlume/RutherfordVac_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RutherfordVac_NicheParts_RealPlume.cfg
@@ -1,24 +1,18 @@
 @PART[ROE-RutherfordVac]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs],*
+	//@MODULE[ModuleEngineConfigs],*
+    //{
+	//	%type = ModuleEnginesRF
+    //    @CONFIG,*
+    //    {
+    //        %powerEffectName = Kerolox-Upper
+    //    }
+	//}
+    PLUME_TEMPLATE
     {
-		%type = ModuleEnginesRF
-        @CONFIG,*
-        {
-            %powerEffectName = Kerolox-Upper
-        }
-	}
-    PLUME
-    {
-        name = Kerolox-Upper
+        name = Kerolox_Upper2
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.1
-        flareScale =    0.5		
-        plumePosition = 0.0, 0.0, 0.17
-        plumeScale =    0.25
-        fixedScale =	0.25
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	0.5
+        scale = 0.323
+		offset = 0
     }
 }

--- a/GameData/ROEngines/RealPlume/Rutherford_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Rutherford_NicheParts_RealPlume.cfg
@@ -1,18 +1,10 @@
 @PART[ROE-Rutherford]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    //@MODULE[ModuleEngineConfigs],*
-    //{
-	//	%type = ModuleEnginesRF
-    //    @CONFIG,*
-    //    {
-    //        %powerEffectName = Kerolox-Lower
-    //    }
-	//}
     PLUME_TEMPLATE
     {
         name = Kerolox_LowerFlame
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.139
-		offset = 0
+        offset = 0
     }
 }

--- a/GameData/ROEngines/RealPlume/Rutherford_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Rutherford_NicheParts_RealPlume.cfg
@@ -1,24 +1,18 @@
 @PART[ROE-Rutherford]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    @MODULE[ModuleEngineConfigs],*
+    //@MODULE[ModuleEngineConfigs],*
+    //{
+	//	%type = ModuleEnginesRF
+    //    @CONFIG,*
+    //    {
+    //        %powerEffectName = Kerolox-Lower
+    //    }
+	//}
+    PLUME_TEMPLATE
     {
-		%type = ModuleEnginesRF
-        @CONFIG,*
-        {
-            %powerEffectName = Kerolox-Lower
-        }
-	}
-    PLUME
-    {
-        name = Kerolox-Lower
+        name = Kerolox_LowerFlame
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.025
-        flareScale =    0.2
-        plumePosition = 0.0, 0.0, 0.1
-        plumeScale =    0.1
-        fixedScale =	0.2
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	0.5
+        scale = 0.139
+		offset = 0
     }
 }

--- a/GameData/ROEngines/RealPlume/S2253_RE_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/S2253_RE_RealPlume.cfg
@@ -2,23 +2,23 @@
 {
     @MODULE[ModuleEngineConfigs],*
     {
-		%type = ModuleEnginesRF
+        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower
         }
-	}
+    }
     PLUME
     {
         name = Kerolox-Lower
-		transformName = thrustTransform
+        transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.0
         flareScale =    0.5
         plumePosition = 0.0, 0.0, -0.2
         plumeScale =    0.25
-        fixedScale =	0.25
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        fixedScale =    0.25
+        energy =        1.0
+        speed =         1.0
+        emissionMult =  1.0
     }
 }

--- a/GameData/ROEngines/RealPlume/S400_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/S400_NicheParts_RealPlume.cfg
@@ -3,23 +3,23 @@
     PLUME
     {
         name = Hypergolic-OMS-White
-		transformName = thrustTransform
+        transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.9
-        flareScale =    0.11		
+        flareScale =    0.11        
         plumePosition = 0.0, 0.0, 0.0
         plumeScale =    0.5
-        fixedScale =	0.5
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        fixedScale =    0.5
+        energy =        1.0
+        speed =         1.0
+        emissionMult =  1.0
     }
-	PLUME_TEMPLATE
+    PLUME_TEMPLATE
     {
         name = Hypergolic_UpperRed
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.19
-		offset = 0.05
-		setupEngine = false
+        offset = 0.05
+        setupEngine = false
     }
 }
 

--- a/GameData/ROEngines/RealPlume/S400_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/S400_NicheParts_RealPlume.cfg
@@ -4,27 +4,22 @@
     {
         name = Hypergolic-OMS-White
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, -.4
-        flareScale =    0.5		
-        plumePosition = 0.0, 0.0, 0.15
+        flarePosition = 0.0, 0.0, -0.9
+        flareScale =    0.11		
+        plumePosition = 0.0, 0.0, 0.0
         plumeScale =    0.5
         fixedScale =	0.5
 		energy = 		1.0
         speed = 		1.0
         emissionMult = 	1.0
     }
-	PLUME
+	PLUME_TEMPLATE
     {
-        name = Hypergolic-OMS-Red
+        name = Hypergolic_UpperRed
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.45
-        flareScale =    0.5		
-        plumePosition = 0.0, 0.0, 0.45
-        plumeScale =    0.5
-        fixedScale =	0.5
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        scale = 0.19
+		offset = 0.05
+		setupEngine = false
     }
 }
 
@@ -39,27 +34,27 @@
 
         @CONFIG[MMH+NTO]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
 
         @CONFIG[MMH+MON3]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
 
         @CONFIG[UDMH+NTO]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
 
         @CONFIG[Aerozine50+NTO]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
 
         @CONFIG[Cavea-B]
         {
-            %powerEffectName = Hypergolic-OMS-Red
+            %powerEffectName = Hypergolic_UpperRed
         }
     }
 }

--- a/GameData/ROEngines/RealPlume/S592_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/S592_NicheParts_RealPlume.cfg
@@ -2,23 +2,23 @@
 {
     @MODULE[ModuleHybridEngine],*
     {
-		%type = ModuleEnginesRF
+        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-White
         }
-	}
+    }
     PLUME
     {
         name = Hypergolic-OMS-White
-		transformName = thrustTransform
+        transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.5
         flareScale =    0.4
         plumePosition = 0.0, 0.0, -0.5
         plumeScale =    0.4
-        fixedScale =	0.4
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        fixedScale =    0.4
+        energy =        1.0
+        speed =         1.0
+        emissionMult =  1.0
     }
 }

--- a/GameData/ROEngines/RealPlume/S598M_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/S598M_NicheParts_RealPlume.cfg
@@ -1,24 +1,24 @@
 @PART[ROE-S598M]:FOR[RealPlume]:NEEDS[SmokeScreen]
-{	
+{   
     @MODULE[ModuleEngineConfigs],*
     {
-		%type = ModuleEnginesRF
+        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-White
         }
-	}
+    }
     PLUME
     {
         name = Hypergolic-OMS-White
-		transformName = thrustTransform
+        transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.5
         flareScale =    0.4
         plumePosition = 0.0, 0.0, -0.5
         plumeScale =    0.4
-        fixedScale =	0.4
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        fixedScale =    0.4
+        energy =        1.0
+        speed =         1.0
+        emissionMult =  1.0
     }
 }

--- a/GameData/ROEngines/RealPlume/STAR5D_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/STAR5D_NicheParts_RealPlume.cfg
@@ -8,18 +8,18 @@
             %powerEffectName = Solid-Vacuum
         }
     }
-	
-	PLUME
+    
+    PLUME
     {
-		name = Solid-Vacuum
+        name = Solid-Vacuum
         transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.4
         flareScale =    0.08
         plumePosition = 0.0, 0.0, 0.45
         plumeScale =    0.2
         //smokePosition = 0.0, 0.0, 0.5
-		//smokeScale = 	0.2
-		energy = 1.0
+        //smokeScale =  0.2
+        energy = 1.0
         speed = 1.0
         emissionMult = 1.0
     }

--- a/GameData/ROEngines/RealPlume/STAR8_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/STAR8_NicheParts_RealPlume.cfg
@@ -8,18 +8,18 @@
             %powerEffectName = Solid-Vacuum
         }
     }
-	
-	PLUME
+    
+    PLUME
     {
-		name = Solid-Vacuum
+        name = Solid-Vacuum
         transformName = thrustTransform
         flarePosition = 0.0, 0.0, 0.45
         flareScale =    0.15
         plumePosition = 0.0, 0.0, 0.5
         plumeScale =    0.4
         //smokePosition = 0.0, 0.0, 0.5
-		//smokeScale = 	0.2
-		energy = 1.0
+        //smokeScale =  0.2
+        energy = 1.0
         speed = 1.0
         emissionMult = 1.0
     }

--- a/GameData/ROEngines/RealPlume/SuperDracoDouble_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/SuperDracoDouble_NicheParts_RealPlume.cfg
@@ -1,25 +1,17 @@
 @PART[ROE-SuperDracoDouble]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	//@MODULE[ModuleEngineConfigs],*
-    //{
-	//	%type = ModuleEnginesRF
-    //    @CONFIG,*
-    //    {
-    //        %powerEffectName = Kerolox-Lower
-    //    }
-	//}
     PLUME_TEMPLATE
     {
         name = Hypergolic_LowerOrangeShock
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.16
-		offset = 0
+        offset = 0
     }
 }
 @PART[ROE-SuperDracoDouble]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
 {
-	@PLUME[Hypergolic_LowerOrangeShock]
-	{
-		@flareScale = 0.04
-	}
+    @PLUME[Hypergolic_LowerOrangeShock]
+    {
+        @flareScale = 0.04
+    }
 }

--- a/GameData/ROEngines/RealPlume/SuperDracoDouble_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/SuperDracoDouble_NicheParts_RealPlume.cfg
@@ -1,24 +1,25 @@
 @PART[ROE-SuperDracoDouble]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs],*
+	//@MODULE[ModuleEngineConfigs],*
+    //{
+	//	%type = ModuleEnginesRF
+    //    @CONFIG,*
+    //    {
+    //        %powerEffectName = Kerolox-Lower
+    //    }
+	//}
+    PLUME_TEMPLATE
     {
-		%type = ModuleEnginesRF
-        @CONFIG,*
-        {
-            %powerEffectName = Kerolox-Lower
-        }
-	}
-    PLUME
-    {
-        name = Kerolox-Lower
+        name = Hypergolic_LowerOrangeShock
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.0
-        flareScale =    0.1
-        plumePosition = 0.0, 0.0, 0.0
-        plumeScale =    0.05
-        fixedScale =	0.1
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	0.5
+        scale = 0.16
+		offset = 0
     }
+}
+@PART[ROE-SuperDracoDouble]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
+{
+	@PLUME[Hypergolic_LowerOrangeShock]
+	{
+		@flareScale = 0.04
+	}
 }

--- a/GameData/ROEngines/RealPlume/SuperDraco_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/SuperDraco_NicheParts_RealPlume.cfg
@@ -1,24 +1,25 @@
 @PART[ROE-SuperDraco]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs],*
+	//@MODULE[ModuleEngineConfigs],*
+    //{
+	//	%type = ModuleEnginesRF
+    //    @CONFIG,*
+    //    {
+    //        %powerEffectName = Kerolox-Lower
+    //    }
+	//}
+    PLUME_TEMPLATE
     {
-		%type = ModuleEnginesRF
-        @CONFIG,*
-        {
-            %powerEffectName = Kerolox-Lower
-        }
-	}
-    PLUME
-    {
-        name = Kerolox-Lower
+        name = Hypergolic_LowerOrangeShock
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.0
-        flareScale =    0.12
-        plumePosition = 0.0, 0.0, 0.01
-        plumeScale =    0.07
-        fixedScale =	0.07
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        scale = 0.16
+		offset = 0
     }
+}
+@PART[ROE-SuperDraco]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
+{
+	@PLUME[Hypergolic_LowerOrangeShock]
+	{
+		@flareScale = 0.04
+	}
 }

--- a/GameData/ROEngines/RealPlume/SuperDraco_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/SuperDraco_NicheParts_RealPlume.cfg
@@ -1,25 +1,17 @@
 @PART[ROE-SuperDraco]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	//@MODULE[ModuleEngineConfigs],*
-    //{
-	//	%type = ModuleEnginesRF
-    //    @CONFIG,*
-    //    {
-    //        %powerEffectName = Kerolox-Lower
-    //    }
-	//}
     PLUME_TEMPLATE
     {
         name = Hypergolic_LowerOrangeShock
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.16
-		offset = 0
+        offset = 0
     }
 }
 @PART[ROE-SuperDraco]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
 {
-	@PLUME[Hypergolic_LowerOrangeShock]
-	{
-		@flareScale = 0.04
-	}
+    @PLUME[Hypergolic_LowerOrangeShock]
+    {
+        @flareScale = 0.04
+    }
 }

--- a/GameData/ROEngines/RealPlume/TD339_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/TD339_NicheParts_RealPlume.cfg
@@ -1,18 +1,10 @@
 @PART[ROE-TD339]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	//@MODULE[ModuleEngineConfigs],*
-    //{
-	//	%type = ModuleEnginesRF
-    //    @CONFIG,*
-    //    {
-    //        %powerEffectName = Hypergolic-OMS-White
-    //    }
-	//}
     PLUME_TEMPLATE
     {
         name = Hypergolic_UpperRed
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.083
-		offset = 0.01
+        offset = 0.01
     }
 }

--- a/GameData/ROEngines/RealPlume/TD339_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/TD339_NicheParts_RealPlume.cfg
@@ -1,24 +1,18 @@
 @PART[ROE-TD339]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs],*
+	//@MODULE[ModuleEngineConfigs],*
+    //{
+	//	%type = ModuleEnginesRF
+    //    @CONFIG,*
+    //    {
+    //        %powerEffectName = Hypergolic-OMS-White
+    //    }
+	//}
+    PLUME_TEMPLATE
     {
-		%type = ModuleEnginesRF
-        @CONFIG,*
-        {
-            %powerEffectName = Hypergolic-OMS-White
-        }
-	}
-    PLUME
-    {
-        name = Hypergolic-OMS-White
+        name = Hypergolic_UpperRed
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, -0.72
-        flareScale =    0.125
-        plumePosition = 0.0, 0.0, -0.72
-        plumeScale =    0.125
-        fixedScale =	0.125
-		energy = 		1.0
-        speed = 		1.0
-        emissionMult = 	1.0
+        scale = 0.083
+		offset = 0.01
     }
 }

--- a/GameData/ROEngines/RealPlume/UA1207_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/UA1207_RN_RealPlume.cfg
@@ -1,30 +1,30 @@
 @PART[ROE-UA1207]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-        @CONFIG,*   					//Add the effect to every engine config
+        @CONFIG,*                       //Add the effect to every engine config
         {
             %powerEffectName = Solid-Lower
         }
     }
-	
+    
     PLUME
     {
-		name = Solid-Lower
+        name = Solid-Lower
         transformName = thrustTransform
         flarePosition = 0.0, 0.0, -0.4
         flareScale =    2.0
-		flareEnergy =	5.0
+        flareEnergy =   5.0
         plumePosition = 0.0, 0.0, 0.2
         plumeScale =    1.7
         smokePosition = 0.0, 0.0, 0.25
-		smokeScale = 	0.2
-		slagPosition = 	0.0, 0.0, 0.2
-		energy = 1.0
+        smokeScale =    0.2
+        slagPosition =  0.0, 0.0, 0.2
+        energy = 1.0
         speed = 1.0
         emissionMult = 1.5
     }
-	
+    
     
 }

--- a/GameData/ROEngines/RealPlume/Wrobz_Sounding_Rockets_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Wrobz_Sounding_Rockets_RealPlume.cfg
@@ -1,10 +1,10 @@
 @PART[ROE-NikeM5E1]:NEEDS[RealPlume,SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesFX
-		%powerEffectName = Solid-Lower
-	}
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesFX
+        %powerEffectName = Solid-Lower
+    }
     PLUME
     {
         name = Solid-Lower

--- a/GameData/ROEngines/RealPlume/X405H_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/X405H_BDB_RealPlume.cfg
@@ -6,6 +6,7 @@
 		transformName = thrustTransform
         scale = 0.5
 		offset = 0.2
+        setupEngine = false
     }
 	PLUME
     {

--- a/GameData/ROEngines/RealPlume/X405H_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/X405H_BDB_RealPlume.cfg
@@ -1,20 +1,20 @@
 @PART[ROE-X405H]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME_TEMPLATE
+    PLUME_TEMPLATE
     {
         name = Kerolox_LowerFlame
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.5
-		offset = 0.2
+        offset = 0.2
         setupEngine = false
     }
-	PLUME
+    PLUME
     {
         name = Kerolox_VernierEagle
-		transformName = vernierEffects
+        transformName = vernierEffects
         localPosition = 0,0,0.05
         plumeScale = 0.1
-		energy = 1
+        energy = 1
         speed = 1
         emissionMult = 1
     }

--- a/GameData/ROEngines/RealPlume/X405H_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/X405H_BDB_RealPlume.cfg
@@ -1,40 +1,32 @@
 @PART[ROE-X405H]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
+	PLUME_TEMPLATE
     {
-        name = Kerolox-Lower
+        name = Kerolox_LowerFlame
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.25
-        flareScale =    0.7
-        plumePosition = 0.0, 0.0, 0.3
-        plumeScale =    0.5
-        fixedScale =	1.0
-		energy = 1.0
-        speed = 1.0
-        emissionMult = 0.5
+        scale = 0.5
+		offset = 0.2
     }
 	PLUME
     {
-        name = Hypergolic-OMS-White
+        name = Kerolox_VernierEagle
 		transformName = vernierEffects
-        flarePosition = 0.0, 0.0, -0.65
-        plumePosition = 0.0, 0.0, 0.0
-        flareScale =    0.07
-        plumeScale =	0.5
-		energy = 0.5
-        speed = 1.0
-        emissionMult = 0.5
+        localPosition = 0,0,0.05
+        plumeScale = 0.1
+		energy = 1
+        speed = 1
+        emissionMult = 1
     }
 }
 @PART[ROE-X405H]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
 {
     @EFFECTS
     {
-        @Kerolox-Lower
+        @Kerolox_LowerFlame
         {
             |_ = CombinedPlume
         }
-        @Hypergolic-OMS-White
+        @Kerolox_VernierEagle
         {
             |_ = CombinedPlume
         }

--- a/GameData/ROEngines/RealPlume/X405_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/X405_BDB_RealPlume.cfg
@@ -6,6 +6,7 @@
 		transformName = thrustTransform
         scale = 0.195
 		offset = 0.89
+        setupEngine = false
     }
 	PLUME
     {

--- a/GameData/ROEngines/RealPlume/X405_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/X405_BDB_RealPlume.cfg
@@ -1,20 +1,20 @@
 @PART[ROE-X405]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME_TEMPLATE
+    PLUME_TEMPLATE
     {
         name = Kerolox_LowerFlame
-		transformName = thrustTransform
+        transformName = thrustTransform
         scale = 0.195
-		offset = 0.89
+        offset = 0.89
         setupEngine = false
     }
-	PLUME
+    PLUME
     {
         name = Kerolox_VernierEagle
-		transformName = vernierTransform
+        transformName = vernierTransform
         localPosition = 0,0,0.05
         plumeScale = 0.1
-		energy = 1
+        energy = 1
         speed = 1
         emissionMult = 1
     }

--- a/GameData/ROEngines/RealPlume/X405_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/X405_BDB_RealPlume.cfg
@@ -1,40 +1,32 @@
 @PART[ROE-X405]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
+	PLUME_TEMPLATE
     {
-        name = Kerolox-Lower
+        name = Kerolox_LowerFlame
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 1.05
-        flareScale =    0.3
-        plumePosition = 0.0, 0.0, 1
-        plumeScale =    0.2
-        fixedScale =	1.0
-		energy = 1.0
-        speed = 1.0
-        emissionMult = 0.5
+        scale = 0.195
+		offset = 0.89
     }
 	PLUME
     {
-        name = Hypergolic-OMS-White
+        name = Kerolox_VernierEagle
 		transformName = vernierTransform
-        flarePosition = 0.0, 0.0, -0.85
-        plumePosition = 0.0, 0.0, 0.05
-        flareScale =    0.07
-        plumeScale =    0.5
-		energy = 0.5
-        speed = 1.0
-        emissionMult = 0.5
+        localPosition = 0,0,0.05
+        plumeScale = 0.1
+		energy = 1
+        speed = 1
+        emissionMult = 1
     }
 }
 @PART[ROE-X405]:FOR[zzPostRealPlumeROEngines]:NEEDS[SmokeScreen]
 {
     @EFFECTS
     {
-        @Kerolox-Lower
+        @Kerolox_LowerFlame
         {
             |_ = CombinedPlume
         }
-        @Hypergolic-OMS-White
+        @Kerolox_VernierEagle
         {
             |_ = CombinedPlume
         }


### PR DESCRIPTION
This PR should fix many of the issues that occured because of the latest SmokeScreen update, and change some of them to the new plume template system (see https://github.com/KSP-RO/RealismOverhaul/pull/2179). Solid rockets still have broken plumes, so those still have to be fixed. Also, the hypergolic plume on the LR91 from RN doesn't really work, but the model is supposed to be replaced anyways.