### PR TITLE
Move aj10-adv thrust origin down

### DIFF
--- a/GameData/ROEngines/PartConfigs/AJ10Adv_MCD.cfg
+++ b/GameData/ROEngines/PartConfigs/AJ10Adv_MCD.cfg
@@ -25,6 +25,18 @@ PART
 		model = ROEngines/Assets/McDouble/ROE-AJ10Adv-MCD
 		scale = 1.0, 1.0, 1.0
 	}
+
+	// The real model has its thrust transform way at the top.
+	// That makes it too easy to accidentally clip it into
+	// another part and end up with obstructed thrust.
+	// We'll put another transform somewhere near the throat
+	// and thrust from there; should be less accident-prone
+	MODEL
+	{
+		model = RealismOverhaul/emptyengine
+		position = 0.0, -0.7, 0.0
+		rotation = 0.0, 0.0, 0.0
+	}
 	
 	scale = 1.0
 	rescaleFactor = 1.0
@@ -61,13 +73,25 @@ PART
 	MODULE
 	{
 		name = ModuleEngines
-		thrustVectorTransformName = thrustTransform
+		thrustVectorTransformName = newThrustTransform
 	}
 	
 	MODULE
 	{
 		name = ModuleGimbal
 		gimbalTransformName = thrustTransform
+		gimbalRange = 4.25
+		useGimbalResponseSpeed = true
+		gimbalResponseSpeed = 9
+	}
+
+	// First ModuleGimbal animates the real model; this one
+	// vectors the transform that actually produces thrust.
+	// They're not perfectly aligned, but close enough.
+	MODULE
+	{
+		name = ModuleGimbal
+		gimbalTransformName = newThrustTransform
 		gimbalRange = 4.25
 		useGimbalResponseSpeed = true
 		gimbalResponseSpeed = 9


### PR DESCRIPTION
Thrust origin was at the top of the model, making it very easy to
occlude it with just a bit of clipping (e.g. from surface attaching).
This is a hackaround using emptyengine's newThrustTransform;
moving the thrustTransform in the actual model would likely be
better.