### PR TITLE
Fix LR87, LR91 hypergolic plume

### DIFF
--- a/GameData/ROEngines/RealPlume/LR87_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR87_RN_RealPlume.cfg
@@ -4,7 +4,7 @@
     {
         name = Hypergolic-Lower
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.0
+        flarePosition = 0.0, 0.0, 0.395
         flareScale =    0.8
         plumePosition = 0.0, 0.0, 0.002
         plumeScale =    1.3

--- a/GameData/ROEngines/RealPlume/LR91_RN_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/LR91_RN_RealPlume.cfg
@@ -23,7 +23,7 @@
     {
         name = Hypergolic-Upper
 		transformName = thrustTransform
-        flarePosition = 0.0, 0.0, 0.0
+        flarePosition = 0.0, 0.0, 0.395
         flareScale =    1.65
         plumePosition = 0.0, 0.0, 0.008
         plumeScale =    2.0


### PR DESCRIPTION
Somehow, with pos=0.0, the flare ends up ~40m forward of
the engine. So push it way down into the bells.

Only tested with smokescreen 2.8.6.0; NOT tested with the latest
batch of releases

Possibly superseded by lukecologne's PR #39; his is explicitly for the newer smokescreen.