### PR TITLE
Fix X-405 and X-405H

### DIFF
--- a/GameData/ROEngines/PartConfigs/X405H_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/X405H_BDB.cfg
@@ -136,6 +136,6 @@ PART
 	@MODULE[ModuleEngineConfigs]
 	{
 		@configuration = X-405H
-		!CONFIG:HAS[~name[X-405]],*{}
+		!CONFIG:HAS[name[X-405]],*{}
 	}
 }

--- a/GameData/ROEngines/PartConfigs/X405H_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/X405H_BDB.cfg
@@ -136,6 +136,6 @@ PART
 	@MODULE[ModuleEngineConfigs]
 	{
 		@configuration = X-405H
-		!CONFIG:HAS[name[X-405]],*{}
+		!CONFIG[X-405] {}
 	}
 }

--- a/GameData/ROEngines/PartConfigs/X405_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/X405_BDB.cfg
@@ -63,6 +63,11 @@ PART
 			name = vernierTransform
 			multiplier = 0.01  // There are 2 of them
 		}
+		THRUST_TRANSFORM
+		{
+			name = vernierEffects
+			multiplier = 0
+		}
 	}
 	
 	// Remove the engine fairing

--- a/GameData/ROEngines/PartConfigs/X405_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/X405_BDB.cfg
@@ -119,6 +119,6 @@ PART
 	
 	@MODULE[ModuleEngineConfigs]
 	{
-		!CONFIG[X-405H] {}
+		!CONFIG:HAS[~name[X-405]],*{}
 	}
 }


### PR DESCRIPTION
Correct the X-405 and X-405H so they use the correct configurations, and prevent a possible bug where the verniers produce full engine thrust.