### PR TITLE
Scale up Juno 6K to better match real proposal

### DIFF
--- a/GameData/ROEngines/PartConfigs/Juno6K_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/Juno6K_BDB.cfg
@@ -26,7 +26,7 @@ PART
 		scale = 1.11, 1.11, 1.11
 	}
 	
-	scale = 1.0
+	scale = 2.0
 	rescaleFactor = 1.0
 	node_stack_top = 0.0, 0.49627, 0.0, 0.0, 1.0, 0.0, 0
 	node_stack_bottom = 0.0, -0.38733, 0.0, 0.0, -1.0, 0.0, 0

--- a/GameData/ROEngines/PartConfigs/Juno6K_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/Juno6K_BDB.cfg
@@ -26,8 +26,8 @@ PART
 		scale = 1.11, 1.11, 1.11
 	}
 	
-	scale = 2.0
-	rescaleFactor = 1.0
+	scale = 1.0
+	rescaleFactor = 2.0
 	node_stack_top = 0.0, 0.49627, 0.0, 0.0, 1.0, 0.0, 0
 	node_stack_bottom = 0.0, -0.38733, 0.0, 0.0, -1.0, 0.0, 0
 	node_attach = 0,0.49627,0,0,1,0,2


### PR DESCRIPTION
This increases the scale of the model to make it closer to what the size of the originally proposed engine would have been, based on drawings and the given target stage size of 1.778m diameter.

![Juno6KResize](https://user-images.githubusercontent.com/161126/82607113-0f615900-9b6d-11ea-8a8e-468d59a4dd61.png)
