### PR TITLE
Block new Agena configs

### DIFF
--- a/GameData/ROEngines/PartConfigs/Agena_SSTU.cfg
+++ b/GameData/ROEngines/PartConfigs/Agena_SSTU.cfg
@@ -275,6 +275,8 @@ PART
 	@MODULE[ModuleEngineConfigs] 
 	{
 		@configuration = XLR81-BA-11
+		!CONFIG[Model117] {}
+		!CONFIG[XLR81-BA-3] {}
 		!CONFIG[XLR81-BA-5] {}
 		!CONFIG[XLR81-BA-7] {}
 		!CONFIG[Model8096L] {}
@@ -439,6 +441,8 @@ PART
 	@MODULE[ModuleEngineConfigs] 
 	{
 		@configuration = Model8096L
+		!CONFIG[Model117] {}
+		!CONFIG[XLR81-BA-3] {}
 		!CONFIG[XLR81-BA-5] {}
 		!CONFIG[XLR81-BA-7] {}
 		!CONFIG[XLR81-BA-11] {}


### PR DESCRIPTION
Block the model117 and XLR81-BA-3 configs from the later Agena models.