### PR TITLE
Don't reduce the mass of the Large Radial clamp

### DIFF
--- a/GameData/ROEngines/PartConfigs/LaunchClamps/LargeRadialLC_FASA.cfg
+++ b/GameData/ROEngines/PartConfigs/LaunchClamps/LargeRadialLC_FASA.cfg
@@ -5,6 +5,4 @@
 	@rescaleFactor = 2.0
 	@title = Large Radial Launch Clamp
 	@description = The Large Radial Launch Clamp is designed to be attached to the sides of rockets to hold them in place before launching.
-	
-	@mass = 0.1
 }


### PR DESCRIPTION
The Medium is 0.5t, reducing the Large to 0.1 is silly.

With krash and kct ignoring clamp masses, might make sense to increase all the clamp masses to reduce rocket wobble, but at a minimum the Large clamp shouldn't be weaker than the Medium.