### PR TITLE
Fix up ROEngine Patches to stop it disabling ROCapsule Engines. (Ready To Review)

### DIFF
--- a/GameData/ROEngines/PatchManager/ActiveMMPatches/AJ10_Adv.cfg
+++ b/GameData/ROEngines/PatchManager/ActiveMMPatches/AJ10_Adv.cfg
@@ -1,2 +1,2 @@
-!PART:HAS[~name[ROE-*],~name[ROC-D2*]|~name[ROC-*]&#engineType[AJ10_Adv]&#category[Engine]]:BEFORE[zzzTagCleanup] {}
+!PART:HAS[~name[ROE-*]|~name[ROC-*]&#engineType[AJ10_Adv]&#category[Engine]]:BEFORE[zzzTagCleanup] {}
 

--- a/GameData/ROEngines/PatchManager/ActiveMMPatches/AJ10_Adv.cfg
+++ b/GameData/ROEngines/PatchManager/ActiveMMPatches/AJ10_Adv.cfg
@@ -1,2 +1,1 @@
-!PART:HAS[~name[ROE-*]|~name[ROC-*]&#engineType[AJ10_Adv]&#category[Engine]]:BEFORE[zzzTagCleanup] {}
-
+!PART:HAS[~name[ROE-*],~name[ROC-D2*]|~name[ROC-*]&#engineType[AJ10_Adv]&#category[Engine]]:BEFORE[zzzTagCleanup] {}

--- a/GameData/ROEngines/PatchManager/ActiveMMPatches/AJ10_Adv.cfg
+++ b/GameData/ROEngines/PatchManager/ActiveMMPatches/AJ10_Adv.cfg
@@ -1,1 +1,2 @@
-!PART:HAS[~name[ROE-*]&#engineType[AJ10_Adv]&#category[Engine]]:BEFORE[zzzTagCleanup] {}
+!PART:HAS[~name[ROE-*],~name[ROC-D2*]|~name[ROC-*]&#engineType[AJ10_Adv]&#category[Engine]]:BEFORE[zzzTagCleanup] {}
+

--- a/GameData/ROEngines/PatchManager/ActiveMMPatches/LMAE.cfg
+++ b/GameData/ROEngines/PatchManager/ActiveMMPatches/LMAE.cfg
@@ -1,1 +1,1 @@
-!PART:HAS[~name[ROE-*]|~name[ROC-*]&#engineType[LMAE]&#category[Engine]]:BEFORE[zzzTagCleanup] {}
+!PART:HAS[~name[ROE-*],~name[ROC-Apollo*]|~name[ROC-*]&#engineType[LMAE]&#category[Engine]]:BEFORE[zzzTagCleanup] {}

--- a/GameData/ROEngines/PatchManager/ActiveMMPatches/LMDE.cfg
+++ b/GameData/ROEngines/PatchManager/ActiveMMPatches/LMDE.cfg
@@ -1,1 +1,1 @@
-!PART:HAS[~name[ROE-*]&#engineType[LMDE]&#category[Engine]]:BEFORE[zzzTagCleanup] {}
+!PART:HAS[~name[ROE-*],~name[ROC-Apollo*]|~name[ROC-*]&#engineType[LMDE]&#category[Engine]]:BEFORE[zzzTagCleanup] {}


### PR DESCRIPTION
Fix up ROEngine Patches to stop it disabling ROCapsule Engines that will affect my Pull Requests.