### PR TITLE
Fix Agena 8096C gimbals

### DIFF
--- a/GameData/ROEngines/PartConfigs/Agena_SSTU.cfg
+++ b/GameData/ROEngines/PartConfigs/Agena_SSTU.cfg
@@ -380,10 +380,14 @@ PART
 		!CONFIG[Model8096-39] {}
 		!CONFIG[Model8096A] {}
 		!CONFIG[XLR81-LF2-SPS] {}
+		@CONFIG,*
+		{
+			!gimbalRange = delete
+		}
 	}
 	@MODULE[ModuleGimbal]:HAS[#gimbalTransformName[yawGimbal]]
 	{
-		%gimbalRange = 3
+		!gimbalRange = delete
 		%gimbalRangeXN = 0
 		%gimbalRangeXP = 0
 		%gimbalRangeYN = 3
@@ -395,6 +399,6 @@ PART
 		%gimbalRangeXP = 3
 		%gimbalRangeYN = 0
 		%gimbalRangeYP = 0
-		%gimbalRange = 3
+		!gimbalRange = delete
 	}
 }


### PR DESCRIPTION
Part has 2 separate 1-axis gimbals. Remove the 2-axis gimbalRange
values that override them.

With this, the two sets of "lock gimbal" and "gimbal limit"
PAW controls correctly affect a single axis each