### PR TITLE
Fix surface attach node on Veronique, s2.s53

### DIFF
--- a/GameData/ROEngines/PartConfigs/S2253_RE.cfg
+++ b/GameData/ROEngines/PartConfigs/S2253_RE.cfg
@@ -5,7 +5,8 @@
 	@manufacturer = NPO Energomash (OKB-456)
 	@description = The S2.253 engine was developed for use in the R-11 Zemlya ballistic missile, based on the Wasserfall engine using Kerosene and Nitric Acid as propellants.  Diameter: 0.88 m.
 	
-	@node_stack_top = 0.0, 1.1843, 0.0, 0.0, 1, 0, 2
+	@node_stack_top[1] -= 1.02
+	@node_attach[1] -= 1.02
 	
 	@tags = scud, s2, 253, r-11, zemlya
 	

--- a/GameData/ROEngines/PartConfigs/Veronique_RE.cfg
+++ b/GameData/ROEngines/PartConfigs/Veronique_RE.cfg
@@ -7,7 +7,8 @@
 	@manufacturer = abc
 	@description = abc
 
-	@node_stack_top = 0.0, 1.1843, 0.0, 0.0, 1, 0, 2
+	@node_stack_top[1] -= 1.02
+	@node_attach[1] -= 1.02
 
 	@tags = veronique, AGI, 61
 


### PR DESCRIPTION
Top of model is deleted and top node moved down accordingly;
surface attachment needs the same treatment.

Also: just offset the y value instead of rewriting the whole node