### PR TITLE
Move Baby Sergeant decouplers to the Coupling category

### DIFF
--- a/GameData/ROEngines/PartConfigs/BabySergeant_RN.cfg
+++ b/GameData/ROEngines/PartConfigs/BabySergeant_RN.cfg
@@ -207,7 +207,7 @@ PART
 	name = ROE-BabySergeantX3Dec
 	author = RaiderNick, Pap
 
-	category = Utility
+	category = Coupling
 	subcategory = 0
 
 	crashTolerance = 10
@@ -271,7 +271,7 @@ PART
 	name = ROE-BabySergeantX11Dec
 	author = RaiderNick, Pap
 
-	category = Utility
+	category = Coupling
 	subcategory = 0
 
 	crashTolerance = 10


### PR DESCRIPTION
... instead of hiding them in the Utility category