### PR TITLE
Better generic thrusters

### DIFF
--- a/GameData/ROEngines/PartConfigs/MR104_NicheParts.cfg
+++ b/GameData/ROEngines/PartConfigs/MR104_NicheParts.cfg
@@ -101,3 +101,29 @@ PART
 		thrustTransformName = thrustTransform
 	}
 }
+
+// TODO: create a ROE-MR104-v2 that ACTUALLY represents MR104, with correct
+// mass, thrust, Isp, fuel? There seems to be a ton of variants, so maybe not.
+
+
+// ROE-MR104 has weirdly high thrust and mass for its size. Deprecate it and
+// replace it by a lighter, weaker version. About half the diameter of the
+// 1.1kN, so make it 1/4 the thrust.
++PART[ROE-MR104]:FIRST
+{
+	@name = ROE-generic-quarter
+	@title = 275/445N Thruster
+	@description ^= :^:A very small thruster for probes. :
+	@useRcsConfig = RCSBlock
+}
+
+@PART[ROE-MR104]:FIRST
+{
+	roeDeprecate = hard
+}
+
+@PART[ROE-generic-quarter]:HAS[@NonRP0]:AFTER[zzzRP-0]
+{
+	*@PART[ROE-MR104]/roeDeprecate = soft
+}
+

--- a/GameData/ROEngines/PartConfigs/PLE_NicheParts.cfg
+++ b/GameData/ROEngines/PartConfigs/PLE_NicheParts.cfg
@@ -104,3 +104,35 @@ PART
 		thrustTransformName = thrustTransform
 	}
 }
+
+// TODO: create a ROE-PLE-v2 that ACTUALLY represents a dual-mr-107 PLE engine,
+// with correct mass, thrust, Isp, fuel?
+
+// ROE-PLE's size and mass are much too low for its thrust, making it better
+// than all the other "generic thrusters".
+// Don't break vessels: create a new part with more appropriate stats,
+// deprecate the old one.
++PART[ROE-PLE]:FIRST
+{
+	@name = ROE-generic-half
+	@title = 550/890N Thruster
+	!mass = delete
+	@useRcsMass = True
+	@rescaleFactor = 2 // make one nozzle about as big as ROE-generic-quarter
+	@description ^= :^:A small thruster for orbital maneuvers and probe course corrections. :
+
+	// yes, the model has two. but the MEANING of "RcsNozzles = 2" is just
+	// "increase the mass for a second nozzle", WITHOUT increasing thrust
+	// accordingly. It's meant for multi-direction rcs blocks.
+	%RcsNozzles = 1
+}
+
+
+@PART[ROE-PLE]:FIRST
+{
+	roeDeprecate = hard
+}
+@PART[ROE-generic-half]:HAS[@NonRP0]:AFTER[zzzRP-0]
+{
+	*@PART[ROE-PLE]/roeDeprecate = soft
+}

--- a/GameData/ROEngines/PartConfigs/S400_NicheParts.cfg
+++ b/GameData/ROEngines/PartConfigs/S400_NicheParts.cfg
@@ -101,3 +101,27 @@ PART
 		thrustTransformName = thrustTransform
 	}
 }
+
+
+// TODO: create a ROE-S400-v2 that ACTUALLY represents S400,
+// with correct mass, thrust, Isp, fuel?
+
+
+// ROE-S400 is weirdly big for its thrust & mass. Deprecate it and replace it by
+// a version with more oomph. We assume RO's generic 1.1/2.2kN thrusters are sanely sized.
++PART[ROE-S400]:FIRST
+{
+	@name = ROE-generic-full
+	@title = 1.1/1.78kN Thruster
+	@description ^= :^:A thruster for orbital maneuvers. :
+	@useRcsConfig = RCSBlock4x
+}
+
+@PART[ROE-S400]:FIRST
+{
+	roeDeprecate = hard
+}
+@PART[ROE-generic-full]:HAS[@NonRP0]:AFTER[zzzRP-0]
+{
+	*@PART[ROE-S400]/roeDeprecate = soft
+}

--- a/GameData/ROEngines/RealPlume/MR104_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/MR104_NicheParts_RealPlume.cfg
@@ -1,4 +1,4 @@
-@PART[ROE-MR104]:BEFORE[RealPlume]:NEEDS[!Waterfall]
+@PART[ROE-MR104|ROE-generic-quarter]:BEFORE[RealPlume]:NEEDS[!Waterfall]
 {
     PLUME
     {

--- a/GameData/ROEngines/RealPlume/PLE_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/PLE_NicheParts_RealPlume.cfg
@@ -1,4 +1,4 @@
-@PART[ROE-PLE]:BEFORE[RealPlume]:NEEDS[!Waterfall]
+@PART[ROE-PLE|ROE-generic-half]:BEFORE[RealPlume]:NEEDS[!Waterfall]
 {
     PLUME
     {
@@ -32,3 +32,18 @@
         @CONFIG[Cavea-B] { %powerEffectName = Hypergolic_UpperRed }
     }
 }
+
+@PART[ROE-generic-half]:BEFORE[RealPlume]
+{
+    @PLUME
+    {
+        @flareScale *= 2
+        @plumeScale *= 2
+        @fixedScale *= 2
+    }
+    @PLUME_TEMPLATE
+    {
+        @scale *= 2 
+    }
+}
+

--- a/GameData/ROEngines/RealPlume/S400_NicheParts_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/S400_NicheParts_RealPlume.cfg
@@ -1,4 +1,4 @@
-@PART[ROE-S400]:BEFORE[RealPlume]:NEEDS[!Waterfall]
+@PART[ROE-S400|ROE-generic-full]:BEFORE[RealPlume]:NEEDS[!Waterfall]
 {
     PLUME
     {

--- a/GameData/ROEngines/Utilities.cfg
+++ b/GameData/ROEngines/Utilities.cfg
@@ -1,0 +1,16 @@
+
+
+// MUST run AFTER[AFTER[zzzRP-0]]
+@PART:HAS[#roeDeprecate[hard]]:LAST[ROEngines]
+{
+	@category = -1
+	@TechRequired = deprecated
+}
+
+@PART:HAS[#roeDeprecate]:LAST[ROEngines]
+{
+	@title ^= :$: (DEPRECATED):
+	!roeDeprecate = delete
+}
+
+

--- a/GameData/ROEngines/Waterfall/Generic/MR104.cfg
+++ b/GameData/ROEngines/Waterfall/Generic/MR104.cfg
@@ -1,4 +1,4 @@
-@PART[ROE-MR104]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+@PART[ROE-MR104|ROE-generic-quarter]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
     ROWaterfall
     {

--- a/GameData/ROEngines/Waterfall/Generic/PLE.cfg
+++ b/GameData/ROEngines/Waterfall/Generic/PLE.cfg
@@ -8,3 +8,13 @@
         scale = 0.05, 0.05, 0.05
     }
 }
+@PART[ROE-generic-half]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        autoConfig = genericThruster
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 0.1, 0.1, 0.1
+    }
+}

--- a/GameData/ROEngines/Waterfall/Generic/S400.cfg
+++ b/GameData/ROEngines/Waterfall/Generic/S400.cfg
@@ -1,4 +1,4 @@
-@PART[ROE-S400]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+@PART[ROE-S400|ROE-generic-full]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
     ROWaterfall
     {


### PR DESCRIPTION
Give the 3 generic thrusters 3 different thrust levels, and give them
appropriate sizes and masses.

As new parts, to avoid breaking vessels; with an experiment in
automatically hiding the old parts once the new parts get the
RO & RP0 treatment