### PR TITLE
Add missing top to Gamma 301

### DIFF
--- a/GameData/ROEngines/PartConfigs/Gamma301_Tantares.cfg
+++ b/GameData/ROEngines/PartConfigs/Gamma301_Tantares.cfg
@@ -11,6 +11,13 @@ PART
 		model = ROEngines/Assets/Tantares/black_knight_engine_s1_1
 	}
 
+	MODEL
+	{
+		model = ROEngines/Assets/Tantares/end_basic_s1_1
+		scale = 0.5, 0.5, 0.5
+		position = 0, 0.5, 0
+	}
+
 	scale = 1
 	rescaleFactor = 1.456
 


### PR DESCRIPTION
This isn't actually how the source part is configured; it uses
some b9ps magic I don't understand. But this asset (currently
used by the stentor) fits like a glove.

Before:
![](https://cdn.discordapp.com/attachments/663102368887472156/825348779552407562/Screen_Shot_2021-03-27_at_08.40.45.png)

After: 
![Screen Shot 2021-04-14 at 17 12 30](https://user-images.githubusercontent.com/5061230/114780903-feea3c00-9d45-11eb-9eee-4fe610783f6e.png)
