### PR TITLE
Waterfall config updates

### DIFF
--- a/GameData/ROEngines/Waterfall/Alcolox/A-4.cfg
+++ b/GameData/ROEngines/Waterfall/Alcolox/A-4.cfg
@@ -25,7 +25,7 @@
     {
         @CONFIG[A-9]
         {
-            %b9psSubtypeName = hydynelox
+            %rowaterfallVariant = hydynelox
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Alcolox/A-4.cfg
+++ b/GameData/ROEngines/Waterfall/Alcolox/A-4.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-alcolox-lower-1
-        audio = pump-fed-gamma-1
+        audio = pump-fed-gamma
         position = 0,0,-0.02
         rotation = 0, 0, 0
         scale = 0.45, 0.45, 0.45

--- a/GameData/ROEngines/Waterfall/Alcolox/A-7.cfg
+++ b/GameData/ROEngines/Waterfall/Alcolox/A-7.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-alcolox-lower-2
-        audio = pump-fed-gamma-1
+        audio = pump-fed-gamma
         position = 0,0,-0.16
         rotation = 0, 0, 0
         scale = 0.59, 0.59, 0.59

--- a/GameData/ROEngines/Waterfall/Alcolox/A-7.cfg
+++ b/GameData/ROEngines/Waterfall/Alcolox/A-7.cfg
@@ -25,7 +25,7 @@
     {
         @CONFIG[A-7]
         {
-            %b9psSubtypeName = hydynelox
+            %rowaterfallVariant = hydynelox
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Alcolox/RD-100.cfg
+++ b/GameData/ROEngines/Waterfall/Alcolox/RD-100.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-alcolox-lower-1
-        audio = pump-fed-gamma-1
+        audio = pump-fed-gamma
         position = 0,0,-0.02
         rotation = 0, 0, 0
         scale = 0.45, 0.45, 0.45

--- a/GameData/ROEngines/Waterfall/Alcolox/XLR-11.cfg
+++ b/GameData/ROEngines/Waterfall/Alcolox/XLR-11.cfg
@@ -3,10 +3,10 @@
     ROWaterfall
     {
         template = waterfall-alcolox-lower-1
-        audio = pump-fed-light-1
+        audio = pump-fed-stentor
         position = 0,0,0.055
         rotation = 0, 0, 0
-        scale = 0.122, 0.15, 0.122
+        scale = 0.15, 0.122, 0.122
         glow = _white
     }
 }

--- a/GameData/ROEngines/Waterfall/Alcolox/XLR-25.cfg
+++ b/GameData/ROEngines/Waterfall/Alcolox/XLR-25.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-alcolox-lower-1
-        audio = pump-fed-light-1
+        audio = pump-fed-stentor
         position = 0,0.104,-0.029
         rotation = -5, 0, 0
         scale = 0.16, 0.16, 0.16

--- a/GameData/ROEngines/Waterfall/Alcolox/XLR41.cfg
+++ b/GameData/ROEngines/Waterfall/Alcolox/XLR41.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-alcolox-lower-1
-        audio = pump-fed-gamma-1
+        audio = pump-fed-gamma
         position = 0,0,-0.02
         rotation = 0, 0, 0
         scale = 0.45, 0.45, 0.45

--- a/GameData/ROEngines/Waterfall/Alcolox/XLR43.cfg
+++ b/GameData/ROEngines/Waterfall/Alcolox/XLR43.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-alcolox-lower-2
-        audio = pump-fed-gamma-1
+        audio = pump-fed-gamma
         position = 0,0,-0.16
         rotation = 0, 0, 0
         scale = 0.59, 0.59, 0.59

--- a/GameData/ROEngines/Waterfall/Ammonialox/XLR99.cfg
+++ b/GameData/ROEngines/Waterfall/Ammonialox/XLR99.cfg
@@ -7,7 +7,7 @@
         audio = pump-fed-medium-1
         position = 0,0,0.013
         rotation = 0, 0, 0
-        scale = 0.582, 0.551, 0.6
+        scale = 0.646, 0.376, 0.6
         glow = _white
 
         ExtraTemplate
@@ -15,7 +15,7 @@
             template = waterfall-hypergolic-vernier-upper-1
             position = -0.406,0.0325,0.016
             rotation = 0, -4, 0
-            scale = 0.35, 0.6, 0.8
+            scale = 0.6, 0.35, 0.8
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hydrolox/LR87_LH2.cfg
+++ b/GameData/ROEngines/Waterfall/Hydrolox/LR87_LH2.cfg
@@ -6,7 +6,7 @@
         audio = pump-fed-medium-1
         position = 0,0,0.27
         rotation = 0, 0, 0
-        scale = 0.68, 0.68, 0.9
+        scale = 0.67, 0.67, 0.9
         glow = ro-hydrolox-red-blue
 
         ExtraTemplate

--- a/GameData/ROEngines/Waterfall/Hydrolox/LR87_LH2V.cfg
+++ b/GameData/ROEngines/Waterfall/Hydrolox/LR87_LH2V.cfg
@@ -6,15 +6,10 @@
         audio = pump-fed-medium-1
         position = 0,0,0.3
         rotation = 0, 0, 0
-        scale = 1.3, 1.3, 1
+        scale = 1.23, 1.23, 1.23
+        glow = ro-hydrolox-blue
+        glowStretch = 1.25
 
-        ExtraTemplate
-        {
-            template = rowaterfall-glow-hydrolox-blue
-            position = 0,0,0.3
-            rotation = 0, 0, 0
-            scale = 1.24, 1.24, 3.5
-        }
         ExtraTemplate
         {
             template = waterfall-hypergolic-vernier-upper-2

--- a/GameData/ROEngines/Waterfall/Hydrolox/RL10A3.cfg
+++ b/GameData/ROEngines/Waterfall/Hydrolox/RL10A3.cfg
@@ -25,7 +25,7 @@
     {
         @CONFIG[CECE-Methane]
         {
-            %b9psSubtypeName = methalox
+            %rowaterfallVariant = methalox
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hydrolox/RL10A4-2N.cfg
+++ b/GameData/ROEngines/Waterfall/Hydrolox/RL10A4-2N.cfg
@@ -24,7 +24,7 @@
     {
         @CONFIG[CECE-Methane]
         {
-            %b9psSubtypeName = methalox
+            %rowaterfallVariant = methalox
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hypergolic/AJ10-Transtar.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/AJ10-Transtar.cfg
@@ -25,7 +25,7 @@
     {
         @CONFIG[AJ10-154]
         {
-            %b9psSubtypeName = hydrolox
+            %rowaterfallVariant = hydrolox
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hypergolic/AJ10Adv.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/AJ10Adv.cfg
@@ -24,7 +24,7 @@
     {
         @CONFIG[AJ10-133-LH]
         {
-            %b9psSubtypeName = hydrolox
+            %rowaterfallVariant = hydrolox
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hypergolic/AJ10Early.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/AJ10Early.cfg
@@ -25,7 +25,7 @@
     {
         @CONFIG[AJ10-118D]
         {
-            %b9psSubtypeName = udmh-irfna
+            %rowaterfallVariant = udmh-irfna
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hypergolic/Aerobee.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/Aerobee.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-hydyne-lower-1
-        audio = pressure-fed-1
+        audio = pump-fed-stentor
         position = 0,0,0.055
         rotation = 0, 0, 0
         scale = 0.1371, 0.1371, 0.1371

--- a/GameData/ROEngines/Waterfall/Hypergolic/Agena8048.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/Agena8048.cfg
@@ -35,11 +35,11 @@
     {
         @CONFIG[Model117]
         {
-            %b9psSubtypeName = kerosene-acid
+            %rowaterfallVariant = kerosene-acid
         }
         @CONFIG[XLR81-BA-3]
         {
-            %b9psSubtypeName = kerosene-acid
+            %rowaterfallVariant = kerosene-acid
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hypergolic/Agena8096.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/Agena8096.cfg
@@ -39,15 +39,15 @@
     {
         @CONFIG[Model8096-39]
         {
-            %b9psSubtypeName = hda-udmh
+            %rowaterfallVariant = hda-udmh
         }
         @CONFIG[Model8096A]
         {
-            %b9psSubtypeName = hda-udmh
+            %rowaterfallVariant = hda-udmh
         }
         @CONFIG[XLR81-LF2-SPS]
         {
-            %b9psSubtypeName = fluorine
+            %rowaterfallVariant = fluorine
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hypergolic/Agena8096C.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/Agena8096C.cfg
@@ -29,7 +29,7 @@
     {
         @CONFIG[Model8096L]
         {
-            %b9psSubtypeName = irfna-mmh
+            %rowaterfallVariant = irfna-mmh
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hypergolic/AgenaSPS.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/AgenaSPS.cfg
@@ -34,11 +34,11 @@
     {
         @CONFIG[TRW-SPS]
         {
-            %b9psSubtypeName = udmh-irfna
+            %rowaterfallVariant = udmh-irfna
         }
         @CONFIG[TRW-SPS-HDA]
         {
-            %b9psSubtypeName = udmh-hda
+            %rowaterfallVariant = udmh-hda
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hypergolic/KTDU-35.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/KTDU-35.cfg
@@ -9,10 +9,13 @@
         audio = pump-fed-light-1
         position = 0,0,0
         rotation = 0, 0, 0
-        scale = 0.28, 0.3, 0.2
+        scale = 0.28, 0.3, 0.3
         glow = _orange
     }
+}
 
+@PART[ROE-KTDU35]:AFTER[ROWaterfall]:NEEDS[Waterfall]
+{
     // Backup engine plume.
     MODULE
     {

--- a/GameData/ROEngines/Waterfall/Hypergolic/LMAE.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/LMAE.cfg
@@ -9,7 +9,7 @@
         scale = 0.665, 0.665, 0.5
         glow = ro-hypergolic-az50
         glowStretch = 0.85
-		
+
 		MainPlumeVariant:NEEDS[B9PartSwitch]
         {
             name = methalox
@@ -25,7 +25,7 @@
     {
         @CONFIG[RS-18]
         {
-            %b9psSubtypeName = methalox
+            %rowaterfallVariant = methalox
         }
     }
 

--- a/GameData/ROEngines/Waterfall/Hypergolic/LR87.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/LR87.cfg
@@ -33,11 +33,11 @@
     {
         @CONFIG[LR87-AJ-3]
         {
-            %b9psSubtypeName = kerolox
+            %rowaterfallVariant = kerolox
         }
         @CONFIG[LR87-AJ-9-Kero]
         {
-            %b9psSubtypeName = kerolox
+            %rowaterfallVariant = kerolox
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hypergolic/LR87.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/LR87.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-hypergolic-aerozine50-lower-1
-        audio = pump-fed-lr87-1
+        audio = pump-fed-lr87
         position = 0,0,0.69
         rotation = 0, 0, 0
         scale = 0.85, 0.85, 0.85

--- a/GameData/ROEngines/Waterfall/Hypergolic/LR87_11.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/LR87_11.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-hypergolic-aerozine50-lower-1
-        audio = pump-fed-lr87-1
+        audio = pump-fed-lr87
         position = 0,0,1
         rotation = 0, 0, 0
         scale = 0.91, 0.91, 0.91

--- a/GameData/ROEngines/Waterfall/Hypergolic/LR87_11.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/LR87_11.cfg
@@ -33,7 +33,7 @@
     {
         @CONFIG[LR87-AJ-9-Kero-15AR]
         {
-            %b9psSubtypeName = kerolox
+            %rowaterfallVariant = kerolox
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hypergolic/LR91.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/LR91.cfg
@@ -34,11 +34,11 @@
     {
         @CONFIG[LR91-AJ-3]
         {
-            %b9psSubtypeName = kerolox
+            %rowaterfallVariant = kerolox
         }
         @CONFIG[LR91-AJ-9-Kero]
         {
-            %b9psSubtypeName = kerolox
+            %rowaterfallVariant = kerolox
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hypergolic/LR91.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/LR91.cfg
@@ -19,18 +19,18 @@
             scale = 1.25, 1.25, 1.25
         }
 
-		MainPlumeVariant:NEEDS[B9PartSwitch]
+        MainPlumeVariant:NEEDS[B9PartSwitch]
         {
             name = kerolox
             template = waterfall-kerolox-upper-3
-            position = 0,0,0.28
+            position = 0,0,0.295
             rotation = 0, 0, 0
             scale = 2.5, 2.5, 2.5
             glowRecolor = _yellow
         }
     }
 
-	@MODULE[ModuleEngineConfigs]:NEEDS[B9PartSwitch]
+    @MODULE[ModuleEngineConfigs]:NEEDS[B9PartSwitch]
     {
         @CONFIG[LR91-AJ-3]
         {

--- a/GameData/ROEngines/Waterfall/Hypergolic/RD-109.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/RD-109.cfg
@@ -53,7 +53,7 @@
         }
         TEMPLATE
         {
-            templateName = rowaterfall-rcs-hypergolic-1
+            templateName = rowaterfall-rcs-hypergolic-2
             overrideParentTransform = VRCSthruster
             position = 0,0,0
             rotation = 0, 0, 180

--- a/GameData/ROEngines/Waterfall/Hypergolic/RD-109.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/RD-109.cfg
@@ -10,7 +10,10 @@
         glow = _yellow
         glowStretch = 1.5
     }
+}
 
+@PART[ROE-RD109]:AFTER[ROWaterfall]:NEEDS[Waterfall]
+{
     MODULE
     {
         name = ModuleWaterfallFX

--- a/GameData/ROEngines/Waterfall/Hypergolic/Viking-2.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/Viking-2.cfg
@@ -8,23 +8,23 @@
         rotation = 0, 0, 0
         scale = 0.85, 0.85, 0.9
         glow = _orange
-		
-		MainPlumeVariant:NEEDS[B9PartSwitch]
+
+        MainPlumeVariant:NEEDS[B9PartSwitch]
         {
             name = uh-25-nto
             template = waterfall-hypergolic-aerozine50-lower-1
             position = 0,0,4
             rotation = 0, 0, 0
             scale = 0.85, 0.85, 0.9
-			glowRecolor = _white
+            glowRecolor = _white
         }
     }
-   
+
     @MODULE[ModuleEngineConfigs]:NEEDS[B9PartSwitch]
     {
         @CONFIG[Viking-2B]
         {
-            %b9psSubtypeName = uh-25-nto
+            %rowaterfallVariant = uh-25-nto
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hypergolic/Viking-4.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/Viking-4.cfg
@@ -9,23 +9,23 @@
         scale = 1.32, 1.32, 1.32
         glow = _orange
         glowStretch = 0.75
-		
-		MainPlumeVariant:NEEDS[B9PartSwitch]
+
+        MainPlumeVariant:NEEDS[B9PartSwitch]
         {
             name = uh-25-nto
             template = waterfall-hypergolic-aerozine50-upper-1
             position = 0,0,4.6
             rotation = 0, 0, 0
             scale = 1.32, 1.32, 1.32
-			glowRecolor = _white
+            glowRecolor = _white
         }
     }
-   
+
     @MODULE[ModuleEngineConfigs]:NEEDS[B9PartSwitch]
     {
         @CONFIG[Viking-4B]
         {
-            %b9psSubtypeName = uh-25-nto
+            %rowaterfallVariant = uh-25-nto
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Kerolox/F1.cfg
+++ b/GameData/ROEngines/Waterfall/Kerolox/F1.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-kerolox-lower-5-film-cooled
-        audio = pump-fed-f1-1
+        audio = pump-fed-f1
         position = 0,0,0
         rotation = 0, 0, 0
         scale = 6.3, 6.55, 6.5

--- a/GameData/ROEngines/Waterfall/Kerolox/F1B.cfg
+++ b/GameData/ROEngines/Waterfall/Kerolox/F1B.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-kerolox-lower-5
-        audio = pump-fed-f1-1
+        audio = pump-fed-f1
         position = 0,0,-0.26
         rotation = 0, 0, 0
         scale = 6.15, 6.4, 6.4

--- a/GameData/ROEngines/Waterfall/Kerosene-Acid/S2_253.cfg
+++ b/GameData/ROEngines/Waterfall/Kerosene-Acid/S2_253.cfg
@@ -21,7 +21,7 @@
     {
         @CONFIG[Isayev-R17]
         {
-            %b9psSubtypeName = udmh-ak27
+            %rowaterfallVariant = udmh-ak27
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Keroxide/Gamma.cfg
+++ b/GameData/ROEngines/Waterfall/Keroxide/Gamma.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-keroxide-lower-1
-        audio = pump-fed-gamma-1
+        audio = pump-fed-gamma
         position = 0,0,0
         rotation = 0, 0, 0
         scale = 0.237, 0.237, 0.237
@@ -17,7 +17,7 @@
     ROWaterfall
     {
         template = waterfall-keroxide-lower-1
-        audio = pump-fed-gamma-1
+        audio = pump-fed-gamma
         position = 0,0,0
         rotation = 0, 0, 0
         scale = 0.212, 0.212, 0.212
@@ -31,7 +31,7 @@
     ROWaterfall
     {
         template = waterfall-keroxide-lower-1
-        audio = pump-fed-gamma-1
+        audio = pump-fed-gamma
         position = 0,0,0
         rotation = 0, 0, 0
         scale = 0.196, 0.196, 0.196

--- a/GameData/ROEngines/Waterfall/Keroxide/Stentor.cfg
+++ b/GameData/ROEngines/Waterfall/Keroxide/Stentor.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-keroxide-lower-1
-        audio = pump-fed-stentor-1
+        audio = pump-fed-stentor
         position = 0,0,0
         rotation = 0, 0, 0
         scale = 0.26, 0.26, 0.26

--- a/GameData/ROEngines/Waterfall/Methalox/Raptor.cfg
+++ b/GameData/ROEngines/Waterfall/Methalox/Raptor.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-methalox-lower-raptor-1
-        audio = pump-fed-raptor-1
+        audio = pump-fed-raptor
         position = 0,0,-0.04
         rotation = 0, 0, 0
         scale = 1.09, 1.09, 1.09

--- a/GameData/ROEngines/Waterfall/Methalox/RaptorVac.cfg
+++ b/GameData/ROEngines/Waterfall/Methalox/RaptorVac.cfg
@@ -3,7 +3,7 @@
     ROWaterfall
     {
         template = waterfall-methalox-upper-raptor-1
-        audio = pump-fed-raptor-1
+        audio = pump-fed-raptor
         position = 0,0,1.36
         rotation = 0, 0, 0
         scale = 2.2, 2.2, 2.2

--- a/GameData/ROEngines/Waterfall/Monopropellant/RangerRetro.cfg
+++ b/GameData/ROEngines/Waterfall/Monopropellant/RangerRetro.cfg
@@ -1,0 +1,11 @@
+@PART[ROE-RangerRetro]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-monopropellant-hydrazine-1
+        audio = pressure-fed-1
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 0.55, 0.55, 0.8
+    }
+}

--- a/GameData/ROEngines/Waterfall/NTR/BNTR.cfg
+++ b/GameData/ROEngines/Waterfall/NTR/BNTR.cfg
@@ -2,24 +2,20 @@
 {
     ROWaterfall
     {
-        template = BDB_nuclear_PBR_vac
+        template = rowaterfall-ntr-1
         audio = pump-fed-light-1
-        position = 0,0,0.3
+        position = 0,0,-0.02
         rotation = 0, 0, 0
-        scale = 2, 2, 2
-
-        ExtraTemplate
-        {
-            template = rowaterfall-glow-ntr
-            position = 0,0,-0.05
-            rotation = 0, 0, 0
-            scale = 1.03, 1.03, 3.8
-        }
+        scale = 2.13, 2.13, 2.13
+        glow = ro-ntr
 
         MainPlumeVariant:NEEDS[B9PartSwitch]
         {
             name = loxAugmented
             template = BDB_nuclear_PBR_sustainer_LOXaug
+            position = 0,0,0.2
+            rotation = 0, 0, 0
+            scale = 2.13, 2.13, 2.13
         }
     }
 

--- a/GameData/ROEngines/Waterfall/NTR/BNTR.cfg
+++ b/GameData/ROEngines/Waterfall/NTR/BNTR.cfg
@@ -23,7 +23,7 @@
     {
         @CONFIG[TRITON]
         {
-            %b9psSubtypeName = loxAugmented
+            %rowaterfallVariant = loxAugmented
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/SRM/AltairI.cfg
+++ b/GameData/ROEngines/Waterfall/SRM/AltairI.cfg
@@ -1,4 +1,4 @@
-@PART[ROE-AltairI]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+@PART[ROE-Altair]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
     ROWaterfall
     {


### PR DESCRIPTION
Batch of Waterfall config updates:

- Update configs for breaking changes made in https://github.com/KSP-RO/RealismOverhaul/pull/2455
- Give Aerobee, XLR-11, and XLR-25 a more interesting sound effect, as requested by @theysen.
- Update BNTR plume to use the new NTR template in non-augmented mode.
- Update RD-109 to use the new big hypergolic RCS template for its vernier.
- Fix patch for Altair I so that it modified the right part.
- Fix squish bug for XLR-11, XLR-99.
- Adjusted plumes of LR-87-LH2, LR-87-LH2V, and LR-91.
- Added plume for new Ranger Retro part.