### PR TITLE
Deprecate the XLR43 part since configs were distributed among other parts

### DIFF
--- a/GameData/ROEngines/PartConfigs/XLR43.cfg
+++ b/GameData/ROEngines/PartConfigs/XLR43.cfg
@@ -104,3 +104,8 @@ PART
 		thrustTransformName = newThrustTransform
 	}
 }
+
+@PART[ROE-XLR43]:HAS[~RSSROConfig[?rue]]:AFTER[zzzRealismOverhaul]
+{
+	roeDeprecate = soft
+}


### PR DESCRIPTION
RO changes are done in https://github.com/KSP-RO/RealismOverhaul/pull/2513