### PR TITLE
Hybrid plumes for SRBs

### DIFF
--- a/GameData/ROEngines/Waterfall/SRM/AJ260.cfg
+++ b/GameData/ROEngines/Waterfall/SRM/AJ260.cfg
@@ -27,7 +27,8 @@
         useRelativeScaling = true
         glow = ro-srm
         glowStretch = 0.1
-		ExtraTemplate
+	
+        ExtraTemplate
         {
             template = rowaterfall-hybrid-srm-1
             transform = vernierTransform

--- a/GameData/ROEngines/Waterfall/SRM/AJ260.cfg
+++ b/GameData/ROEngines/Waterfall/SRM/AJ260.cfg
@@ -8,9 +8,9 @@
         position = 0,0.06,0.5
         rotation = 3, 0, 0
         scale = 4.9, 4.9, 5
-		useRelativeScaling = true
+        useRelativeScaling = true
         glow = ro-srm
-		glowStretch = 0.1
+        glowStretch = 0.1
     }
 }
 
@@ -24,9 +24,9 @@
         position = 0,0,0.75
         rotation = 0, 0, 0
         scale = 4.9, 4.9, 5
-		useRelativeScaling = true
+        useRelativeScaling = true
         glow = ro-srm
-		glowStretch = 0.1
+        glowStretch = 0.1
 		ExtraTemplate
         {
             template = rowaterfall-hybrid-srm-1

--- a/GameData/ROEngines/Waterfall/SRM/AJ260.cfg
+++ b/GameData/ROEngines/Waterfall/SRM/AJ260.cfg
@@ -1,0 +1,39 @@
+@PART[ROE-AJ260SLA|ROE-AJ260FLA]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0.06,0.5
+        rotation = 3, 0, 0
+        scale = 4.9, 4.9, 5
+		useRelativeScaling = true
+        glow = ro-srm
+		glowStretch = 0.1
+    }
+}
+
+@PART[|ROE-AJ260SLF|ROE-AJ260FLF]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0.75
+        rotation = 0, 0, 0
+        scale = 4.9, 4.9, 5
+		useRelativeScaling = true
+        glow = ro-srm
+		glowStretch = 0.1
+		ExtraTemplate
+        {
+            template = rowaterfall-hybrid-srm-1
+            transform = vernierTransform
+            position = 0,0,0
+            rotation = 0, 0, 0
+            scale = 0.95, 0.95, 0.9
+        }
+    }
+}

--- a/GameData/ROEngines/Waterfall/SRM/AerobeeSolids.cfg
+++ b/GameData/ROEngines/Waterfall/SRM/AerobeeSolids.cfg
@@ -1,0 +1,28 @@
+@PART[ROE-25KS18000]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 0.39, 0.39, 0.39
+        glow = ro-srm
+        glowStretch = 0.1
+    }
+}
+@PART[ROE-18KS7800]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 0.24, 0.24, 0.2
+        glow = ro-srm
+        glowStretch = 0.1
+    }
+}

--- a/GameData/ROEngines/Waterfall/SRM/Algols.cfg
+++ b/GameData/ROEngines/Waterfall/SRM/Algols.cfg
@@ -1,0 +1,26 @@
+@PART[ROE-Algol1|ROE-Algol2]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0.225
+        rotation = 0, 0, 0
+        scale = 1.15, 1.35, 1.35
+        glow = ro-srm
+    }
+}
+@PART[ROE-Algol1_Inline|ROE-Algol2_Inline]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 1.15, 1.35, 1.35
+        glow = ro-srm
+    }
+}

--- a/GameData/ROEngines/Waterfall/SRM/Castor120.cfg
+++ b/GameData/ROEngines/Waterfall/SRM/Castor120.cfg
@@ -1,0 +1,13 @@
+@PART[ROE-Castor120]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0.16
+        rotation = 0, 0, 0
+        scale = 2.11, 2.11, 2.11
+        glow = ro-srm
+    }
+}

--- a/GameData/ROEngines/Waterfall/SRM/EarlyCastors.cfg
+++ b/GameData/ROEngines/Waterfall/SRM/EarlyCastors.cfg
@@ -1,0 +1,52 @@
+@PART[ROE-Castor1]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 0.7, 0.7, 0.7
+        glow = ro-srm
+    }
+}
+@PART[ROE-Castor2]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 0.74, 0.74, 0.74
+        glow = ro-srm
+    }
+}
+@PART[ROE-Castor1_Inline|ROE-Castor2_Inline]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0.15
+        rotation = 0, 0, 0
+        scale = 0.884, 0.884, 0.9
+        glow = ro-srm
+    }
+}
+@PART[ROE-Castor4|ROE-Castor4AXL]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 1.23, 0.7, 1
+        glow = ro-srm
+    }
+}

--- a/GameData/ROEngines/Waterfall/SRM/GEMs.cfg
+++ b/GameData/ROEngines/Waterfall/SRM/GEMs.cfg
@@ -22,14 +22,8 @@
         position = 0,0,0.11
         rotation = 0, 0, 0
         scale = 1.03, 1.03, 1.03
-		
-        ExtraTemplate
-        {
-            template = rowaterfall-glow-srm
-            position = 0,0,0.11
-            rotation = 0, 0, 0
-            scale = 0.63, 0.63, 0.1
-        }
+        glowStretch = 0.1
+        glow = ro-srm
 		
         MainPlumeVariant:NEEDS[B9PartSwitch]
         {
@@ -38,6 +32,7 @@
             position = 0,0,0.32
             rotation = 0, 0, 0
             scale = 1.47, 1.47, 1.2
+	    recomputeGlowSize = true
         }
     }
 
@@ -50,27 +45,6 @@
     }
 }
 
-@PART[ROE-GEM40]:AFTER[zROWaterfall_Post]:NEEDS[Waterfall,B9PartSwitch]
-{
-    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[rowaterfallMainPlumeSwitch]]
-    {
-        @SUBTYPE[airlit]
-        {
-            @MODULE
-            {
-                @DATA
-                {
-                    @TEMPLATE:HAS[#templateName[rowaterfall-glow-srm]]
-                    {
-                        @position = 0,0,0.32
-                        @rotation = 0, 0, 0
-                        @scale = 0.9, 0.9, 0.1
-                    }
-                }
-            }
-        }
-    }
-}
 @PART[ROE-GEM46]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
 {
     ROWaterfall
@@ -81,22 +55,17 @@
         position = 0,0,0.085
         rotation = 0, 0, 0
         scale = 1.21, 1.21, 1.21
+	glowStretch = 0.1
+        glow = ro-srm
 		
-	    ExtraTemplate
-        {
-            template = rowaterfall-glow-srm
-            position = 0,0,0.11
-            rotation = 0, 0, 0
-            scale = 0.74, 0.74, 0.1
-        }
-		
-		MainPlumeVariant:NEEDS[B9PartSwitch]
+        MainPlumeVariant:NEEDS[B9PartSwitch]
         {
             name = airlit
             template = rowaterfall-hybrid-srm-1
             position = 0,0,0.28
             rotation = 0, 0, 0
             scale = 1.57, 1.57, 1.2
+	    recomputeGlowSize = true
         }
     }
 
@@ -105,28 +74,6 @@
         @CONFIG[GEM-46/Fixed-Air]
         {
             %rowaterfallVariant = airlit
-        }
-    }
-}
-
-@PART[ROE-GEM46]:AFTER[zROWaterfall_Post]:NEEDS[Waterfall,B9PartSwitch]
-{
-    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[rowaterfallMainPlumeSwitch]]
-    {
-        @SUBTYPE[airlit]
-        {
-            @MODULE
-            {
-                @DATA
-                {
-                    @TEMPLATE:HAS[#templateName[rowaterfall-glow-srm]]
-                    {
-                        @position = 0,0,0.28
-                        @rotation = 0, 0, 0
-                        @scale = 0.96, 0.96, 0.1
-                    }
-                }
-            }
         }
     }
 }
@@ -141,7 +88,7 @@
         position = 0,0,0.3
         rotation = 0, 0, 0
         scale = 1.47, 1.47, 1.47
-        glowStretch = 0.1
+	glowStretch = 0.1
         glow = ro-srm
     }
 }

--- a/GameData/ROEngines/Waterfall/SRM/GEMs.cfg
+++ b/GameData/ROEngines/Waterfall/SRM/GEMs.cfg
@@ -141,7 +141,7 @@
         position = 0,0,0.3
         rotation = 0, 0, 0
         scale = 1.47, 1.47, 1.47
-		glowStretch = 0.1
+        glowStretch = 0.1
         glow = ro-srm
     }
 }

--- a/GameData/ROEngines/Waterfall/SRM/GEMs.cfg
+++ b/GameData/ROEngines/Waterfall/SRM/GEMs.cfg
@@ -1,0 +1,145 @@
+@PART[ROE-AJ60]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 1.5, 1.5, 1.5
+        glow = ro-srm
+    }
+}
+@PART[ROE-GEM40]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0.11
+        rotation = 0, 0, 0
+        scale = 1.03, 1.03, 1.03
+		
+		ExtraTemplate
+        {
+            template = rowaterfall-glow-srm
+            position = 0,0,0.11
+            rotation = 0, 0, 0
+            scale = 0.63, 0.63, 0.1
+        }
+		
+		MainPlumeVariant:NEEDS[B9PartSwitch]
+        {
+            name = airlit
+            template = rowaterfall-hybrid-srm-1
+            position = 0,0,0.32
+            rotation = 0, 0, 0
+            scale = 1.47, 1.47, 1.2
+        }
+    }
+
+    @MODULE[ModuleEngineConfigs]:NEEDS[B9PartSwitch]
+    {
+        @CONFIG[GEM-40/Air]
+        {
+            %rowaterfallVariant = airlit
+        }
+    }
+}
+@PART[ROE-GEM40]:AFTER[zROWaterfall_Post]:NEEDS[Waterfall,B9PartSwitch]
+{
+    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[rowaterfallMainPlumeSwitch]]
+    {
+        @SUBTYPE[airlit]
+        {
+            @MODULE
+            {
+                @DATA
+                {
+                    @TEMPLATE:HAS[#templateName[rowaterfall-glow-srm]]
+                    {
+						@position = 0,0,0.32
+                        @rotation = 0, 0, 0
+                        @scale = 0.9, 0.9, 0.1
+                    }
+                }
+            }
+        }
+    }
+}
+@PART[ROE-GEM46]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0.085
+        rotation = 0, 0, 0
+        scale = 1.21, 1.21, 1.21
+		
+	    ExtraTemplate
+        {
+            template = rowaterfall-glow-srm
+            position = 0,0,0.11
+            rotation = 0, 0, 0
+            scale = 0.74, 0.74, 0.1
+        }
+		
+		MainPlumeVariant:NEEDS[B9PartSwitch]
+        {
+            name = airlit
+            template = rowaterfall-hybrid-srm-1
+            position = 0,0,0.28
+            rotation = 0, 0, 0
+            scale = 1.57, 1.57, 1.2
+        }
+    }
+
+    @MODULE[ModuleEngineConfigs]:NEEDS[B9PartSwitch]
+    {
+        @CONFIG[GEM-46/Fixed-Air]
+        {
+            %rowaterfallVariant = airlit
+        }
+    }
+}
+
+@PART[ROE-GEM46]:AFTER[zROWaterfall_Post]:NEEDS[Waterfall,B9PartSwitch]
+{
+    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[rowaterfallMainPlumeSwitch]]
+    {
+        @SUBTYPE[airlit]
+        {
+            @MODULE
+            {
+                @DATA
+                {
+                    @TEMPLATE:HAS[#templateName[rowaterfall-glow-srm]]
+                    {
+                        @position = 0,0,0.28
+                        @rotation = 0, 0, 0
+                        @scale = 0.96, 0.96, 0.1
+                    }
+                }
+            }
+        }
+    }
+}
+
+@PART[ROE-GEM60|ROE-GEM63]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0.3
+        rotation = 0, 0, 0
+        scale = 1.47, 1.47, 1.47
+		glowStretch = 0.1
+        glow = ro-srm
+    }
+}

--- a/GameData/ROEngines/Waterfall/SRM/GEMs.cfg
+++ b/GameData/ROEngines/Waterfall/SRM/GEMs.cfg
@@ -11,6 +11,7 @@
         glow = ro-srm
     }
 }
+
 @PART[ROE-GEM40]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
 {
     ROWaterfall
@@ -22,7 +23,7 @@
         rotation = 0, 0, 0
         scale = 1.03, 1.03, 1.03
 		
-		ExtraTemplate
+        ExtraTemplate
         {
             template = rowaterfall-glow-srm
             position = 0,0,0.11
@@ -30,7 +31,7 @@
             scale = 0.63, 0.63, 0.1
         }
 		
-		MainPlumeVariant:NEEDS[B9PartSwitch]
+        MainPlumeVariant:NEEDS[B9PartSwitch]
         {
             name = airlit
             template = rowaterfall-hybrid-srm-1
@@ -48,6 +49,7 @@
         }
     }
 }
+
 @PART[ROE-GEM40]:AFTER[zROWaterfall_Post]:NEEDS[Waterfall,B9PartSwitch]
 {
     @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[rowaterfallMainPlumeSwitch]]
@@ -60,7 +62,7 @@
                 {
                     @TEMPLATE:HAS[#templateName[rowaterfall-glow-srm]]
                     {
-						@position = 0,0,0.32
+                        @position = 0,0,0.32
                         @rotation = 0, 0, 0
                         @scale = 0.9, 0.9, 0.1
                     }


### PR DESCRIPTION
Adds hybrid wfss plumes for the following SRBs:
Algols IB and II (inline and radial)
Castors 1, 2, 4, 4AXL and 120 (inline and radial)
AJ-260 FL and SL (inline and radial)
AJ-60
GEMs 40, 46, 60, 63 (ground-lit and air-lit)
25KS18000 and 18KS7800