### PR TITLE
Update Waterfall configs for LR89 and A-7 engines as per RO and RP-1's changes

### DIFF
--- a/GameData/ROEngines/Waterfall/Alcolox/A-7.cfg
+++ b/GameData/ROEngines/Waterfall/Alcolox/A-7.cfg
@@ -23,7 +23,7 @@
 
     @MODULE[ModuleEngineConfigs]:NEEDS[B9PartSwitch]
     {
-        @CONFIG[A-7]
+        @CONFIG[A-6H]
         {
             %rowaterfallVariant = hydynelox
         }

--- a/GameData/ROEngines/Waterfall/Kerolox/LR89.cfg
+++ b/GameData/ROEngines/Waterfall/Kerolox/LR89.cfg
@@ -9,5 +9,23 @@
         scale = 2.13, 2.13, 2
         glow = _yellow
         glowStretch = 0.75
+		
+		MainPlumeVariant:NEEDS[B9PartSwitch]
+        {
+            name = alco
+            template = waterfall-alcolox-lower-2
+            position = 0,0,0.26
+            rotation = 0, 0, 0
+            scale = 0.8946, 0.8946, 0.8946
+            glowRecolor = _white
+        }
+    }
+	
+    @MODULE[ModuleEngineConfigs]:NEEDS[B9PartSwitch]
+    {
+        @CONFIG[XLR43-NA-3]
+        {
+            %rowaterfallVariant = alco
+        }
     }
 }


### PR DESCRIPTION
A-6H now uses hydynelox plume
A-7 uses alcolox plume
The first config of LR89, XLR43-NA-3, uses alcolox plume