### PR TITLE
Reduce Engine Crash Tolerance

### DIFF
--- a/GameData/ROEngines/ROEEngineDefaults.cfg
+++ b/GameData/ROEngines/ROEEngineDefaults.cfg
@@ -1,6 +1,6 @@
 @PART:HAS[#ROESetEngineDefaults]:FIRST
 {
-	%crashTolerance = 10
+	%crashTolerance = 2
 	%maxTemp = 673.15
 	%skinMaxTemp = 773.15
 	%fuelCrossFeed = true


### PR DESCRIPTION
Reduce engine crash tolerance to a much lower number. Players should probably not be able to land on engine bells, and expect the engine to keep working.