### PR TITLE
Correct scale of RD-170 and RD-191

### DIFF
--- a/GameData/ROEngines/PartConfigs/RD170_SSTU.cfg
+++ b/GameData/ROEngines/PartConfigs/RD170_SSTU.cfg
@@ -12,16 +12,14 @@ PART
 
 	MODEL
 	{
-		// Dimensions: 2.4 x 2.44438
 		model = ROEngines/Assets/SSTU/SC-ENG-RD-171
-		// RL Dimensions: 4.0 x 3.8 m
-		scale = 1.5656, 1.5656, 1.5656
+		scale = 1.0, 1.0, 1.0
 	}
 
 	scale = 1.0
-	rescaleFactor = 1.0
+	rescaleFactor = 1.4653
 	node_stack_top = 0,0,0,0,1,0,2
-	node_stack_bottom = 0,-3.77,0,0,-1,0,2
+	node_stack_bottom = 0,-2.408,0,0,-1,0,2
 	node_attach = 0,0,0,0,1,0,2
 	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,1,0

--- a/GameData/ROEngines/PartConfigs/RD191_SSTU.cfg
+++ b/GameData/ROEngines/PartConfigs/RD191_SSTU.cfg
@@ -12,16 +12,14 @@ PART
 
 	MODEL
 	{
-		// Dimensions: 2.4 x 0.96580
 		model = ROEngines/Assets/SSTU/SC-ENG-RD-181
-		// RL Dimensions: 3.58 x 1.45 m
-		scale = 1.5656, 1.5656, 1.5656
+		scale = 1.0, 1.0, 1.0
 	}
 
 	scale = 1.0
-	rescaleFactor = 1.0
+	rescaleFactor = 1.4653
 	node_stack_top = 0,0,0,0,1,0,2
-	node_stack_bottom = 0,-3.7574,0,0,-1,0,2
+	node_stack_bottom = 0,-2.4,0,0,-1,0,2
 	node_attach = 0,0,0,0,1,0,2
 	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,1,0

--- a/GameData/ROEngines/RealPlume/RD170_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD170_SSTU_RealPlume.cfg
@@ -8,7 +8,7 @@
     {
         name = Kerolox_LowerFlame
         transformName = RD-171-ThrustTransform
-        scale = 0.93
+        scale = 0.8578
         offset = 1.45
     }
 

--- a/GameData/ROEngines/RealPlume/RD191_SSTU_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/RD191_SSTU_RealPlume.cfg
@@ -8,7 +8,7 @@
     {
         name = Kerolox_LowerFlame
         transformName = RD-181-ThrustTransform
-        scale = 0.93
+        scale = 0.8578
         offset = 1.45
     }
 

--- a/GameData/ROEngines/Waterfall/Kerolox/RD-170.cfg
+++ b/GameData/ROEngines/Waterfall/Kerolox/RD-170.cfg
@@ -7,7 +7,7 @@
         transform = RD-171-ThrustTransform
         position = 0,0,1.55
         rotation = 0, 0, 0
-        scale = 3, 3, 3
+        scale = 2.81, 2.81, 2.81
         glow = _yellow
     }
 }

--- a/GameData/ROEngines/Waterfall/Kerolox/RD-191.cfg
+++ b/GameData/ROEngines/Waterfall/Kerolox/RD-191.cfg
@@ -7,7 +7,7 @@
         transform = RD-181-ThrustTransform
         position = 0,0,1.55
         rotation = 0, 0, 0
-        scale = 3, 3, 3
+        scale = 2.81, 2.81, 2.81
         glow = _yellow
     }
 }


### PR DESCRIPTION
Correct scale of RD-170 (it was scaled such that the engine mount fit within 3.9 meters, but the engine bells protruded out past 3.9 meters. Now scaled so that the entire engine fits within 3.9 meters), and changed scale of RD-191 to match. RD-180 appears to already be at correct scale.