### PR TITLE
Fix Scout RCS, add Algol III

### DIFF
--- a/GameData/ROEngines/PartConfigs/Algol3_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/Algol3_BDB.cfg
@@ -1,7 +1,7 @@
 PART
 {
 	module = Part
-	name = ROE-Algol2
+	name = ROE-Algol3
 	author = Cobaltwolf, Pap
 
 	ROESetEngineDefaults = SOLID_BOOSTER
@@ -13,12 +13,12 @@ PART
 	MODEL
 	{
 		model = ROEngines/Assets/BDB/Solids/bluedog_Scout_Algol_Radial
-		scale = 0.833, 1, 0.833
+		scale = 0.910, 1, 0.910
 	}
 
 	scale = 1.0
-	rescaleFactor = 1.311
-	node_attach = 0.3905, 0.0, 0.0, 1.0, 0.0, 0.0, 1
+	rescaleFactor = 1.354
+	node_attach = 0.4267, 0.0, 0.0, 1.0, 0.0, 0.0, 1
 	CoMOffset = 0.234, -0.234, 0.0
 	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,1,0
@@ -29,7 +29,7 @@ PART
 
 	tags = algol, algol2, algol-2, 2, scout
 
-	engineType = Algol-II
+	engineType = Algol-III
 
 	skinInternalConductionMult = 4.0
 	emissiveConstant = 0.5
@@ -73,7 +73,7 @@ PART
 		}
 	}
 }
-@PART[ROE-Algol2]:AFTER[RealismOverhaulEngines]
+@PART[ROE-Algol3]:AFTER[RealismOverhaulEngines]
 {
 	// Remove gimbal since radial model doesn't have thrust vanes
 	!MODULE[ModuleGimbal] {}

--- a/GameData/ROEngines/PartConfigs/Algol3_Inline_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/Algol3_Inline_BDB.cfg
@@ -1,0 +1,106 @@
+PART
+{
+	module = Part
+	name = ROE-Algol3_Inline
+	author = Cobaltwolf, Pap
+
+	ROESetEngineDefaults = SOLID_BOOSTER
+
+	//  ============================================================================
+	//	Update Below
+	//  ============================================================================
+
+	MODEL
+	{
+		model = ROEngines/Assets/BDB/Solids/bluedog_Scout_Algol_Inline
+		scale = 0.910, 1, 0.910
+	}
+	//Thrust Vanes
+	MODEL
+	{
+		model = RealismOverhaul/emptyengine
+		position = 0.15, -3.477, 0.0
+		rotation = 0.0, 0.0, 0.0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/emptyengine
+		position = -0.15, -3.477, 0.0
+		rotation = 0.0, 0.0, 0.0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/emptyengine
+		position = 0.0, -3.477, 0.15
+		rotation = 0.0, 0.0, 0.0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/emptyengine
+		position = 0.0, -3.477, -0.15
+		rotation = 0.0, 0.0, 0.0
+	}
+
+	scale = 1.0
+	rescaleFactor = 1.354
+	node_stack_bottom = 0.0, -3.477, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 3.54, 0.0, 0.0, 1.0, 0.0, 1
+	node_attach = 0.0, 0.0, -0.3905, 0.0, 0.0, 1.0, 1
+	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+	attachRules = 1,1,1,1,0
+
+	title = Algol
+	manufacturer = Thiokol
+	description = abc
+
+	tags = algol, algol2, algol-2, 2, scout
+
+	engineType = Algol-III
+
+	skinInternalConductionMult = 4.0
+	emissiveConstant = 0.5
+	dragModelType = default
+	maximum_drag = 0.3
+	minimum_drag = 0.2
+	angularDrag = 2
+
+	MODULE
+	{
+		name = ModuleEnginesRF
+		thrustVectorTransformName = newThrustTransform
+	}
+
+	MODULE
+	{
+		name = ModuleSurfaceFX
+		thrustProviderModuleIndex = 0
+		fxMax = 1
+		maxDistance = 80
+		falloff = 2
+		thrustTransformName = newThrustTransform
+	}
+}
+@PART[ROE-Algol3_Inline]:AFTER[RealismOverhaulEngines]
+{
+	!MODULE[ModuleGimbal],* { }
+	
+	MODULE //MainGimbal
+	{
+		name = ModuleGimbal
+		gimbalResponseSpeed = 16
+		useGimbalResponseSpeed = true
+		gimbalTransformName = newThrustTransform
+		gimbalRange = 6.0
+	}
+	MODULE //Thrust Vanes
+	{
+		name = ModuleGimbal
+		gimbalResponseSpeed = 16
+		useGimbalResponseSpeed = true
+		gimbalTransformName = ControlGimbal
+		gimbalRangeXN = 7
+		gimbalRangeXP = 7
+		gimbalRangeYN = 0
+		gimbalRangeYP = 0
+	}
+}

--- a/GameData/ROEngines/PartConfigs/Antares1_Inline_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/Antares1_Inline_BDB.cfg
@@ -74,14 +74,27 @@ PART
 		name = ModuleRCSFX
 		stagingEnabled = True
 		thrusterTransformName = rcsTransform
-		thrusterPower = 0.05
-		resourceName = Nitrogen
+		thrusterPower = 0.26
+		//60 lbf pitch/yaw thrusters , 14 lbf roll thrusters source:https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2401&context=smallsat
+		resourceName = HTP
 		resourceFlowMode = STACK_PRIORITY_SEARCH
 		runningEffectName = control
+		PROPELLANT
+		{
+			ratio = 1.0
+			name = HTP
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 11.25
+			ignoreForIsp = True
+		}
 		atmosphereCurve
 		{
-			key = 0 57
-			key = 1 26
+			key = 0 140
+			key = 1 90
 		}
 	}
 
@@ -111,19 +124,44 @@ PART
 }
 @PART[ROE-Antares1_Inline]:AFTER[RealismOverhaulEngines]
 {
-	@mass += 0.03	//Add mass of RCS system
+	@mass += 0.036	//Add mass of RCS system
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		@origMass += 0.036
+	}
+
+	//Remove MFT and just put the propellant in a stock tank so we can use the tank for RCS
+	!MODULE[ModuleFuelTanks] {}
+
+	RESOURCE
+	{
+		name = PBAA
+		amount = 533.712923
+		maxAmount = 533.712923
+	}
+
+	//Source: https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2401&context=smallsat
+	//counting pixels, Scout 3rd stage contains 2 spherical tanks with a radius of ~0.1 meters
+	//Total volume ~8.5 liters
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 20
+		volume = 8.5
 		type = ServiceModule
 		basemass = -1
 		
 		TANK
 		{
-			name = Nitrogen
-			amount = 4000
-			maxAmount = 4000
+			name = HTP
+			amount = 8.04733727810651
+			maxAmount = 8.04733727810651
+		}
+		TANK
+		{
+			name = Helium
+			amount = 90.5325443786982
+			maxAmount = 90.5325443786982
 		}
 	}
 }

--- a/GameData/ROEngines/PartConfigs/Antares2_Inline_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/Antares2_Inline_BDB.cfg
@@ -74,14 +74,27 @@ PART
 		name = ModuleRCSFX
 		stagingEnabled = True
 		thrusterTransformName = rcsTransform
-		thrusterPower = 0.05
-		resourceName = Nitrogen
+		thrusterPower = 0.26
+		//60 lbf pitch/yaw thrusters , 14 lbf roll thrusters source:https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2401&context=smallsat
+		resourceName = HTP
 		resourceFlowMode = STACK_PRIORITY_SEARCH
 		runningEffectName = control
+		PROPELLANT
+		{
+			ratio = 1.0
+			name = HTP
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 11.25
+			ignoreForIsp = True
+		}
 		atmosphereCurve
 		{
-			key = 0 57
-			key = 1 26
+			key = 0 140
+			key = 1 90
 		}
 	}
 
@@ -111,19 +124,44 @@ PART
 }
 @PART[ROE-Antares2_Inline]:AFTER[RealismOverhaulEngines]
 {
-	@mass += 0.03	//Add mass of RCS system
+	@mass += 0.036	//Add mass of RCS system
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		@origMass += 0.036
+	}
+
+	//Remove MFT and just put the propellant in a stock tank so we can use the tank for RCS
+	!MODULE[ModuleFuelTanks] {}
+
+	RESOURCE
+	{
+		name = PBAA
+		amount = 654.534424
+		maxAmount = 654.534424
+	}
+
+	//Source: https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2401&context=smallsat
+	//counting pixels, Scout 3rd stage contains 2 spherical tanks with a radius of ~0.1 meters
+	//Total volume ~8.5 liters
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 20
+		volume = 8.5
 		type = ServiceModule
 		basemass = -1
-
+		
 		TANK
 		{
-			name = Nitrogen
-			amount = 4000
-			maxAmount = 4000
+			name = HTP
+			amount = 8.04733727810651
+			maxAmount = 8.04733727810651
+		}
+		TANK
+		{
+			name = Helium
+			amount = 90.5325443786982
+			maxAmount = 90.5325443786982
 		}
 	}
 }

--- a/GameData/ROEngines/PartConfigs/Antares3_Inline_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/Antares3_Inline_BDB.cfg
@@ -74,14 +74,27 @@ PART
 		name = ModuleRCSFX
 		stagingEnabled = True
 		thrusterTransformName = rcsTransform
-		thrusterPower = 0.05
-		resourceName = Nitrogen
+		thrusterPower = 0.26
+		//60 lbf pitch/yaw thrusters , 14 lbf roll thrusters source:https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2401&context=smallsat
+		resourceName = HTP
 		resourceFlowMode = STACK_PRIORITY_SEARCH
 		runningEffectName = control
+		PROPELLANT
+		{
+			ratio = 1.0
+			name = HTP
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 11.25
+			ignoreForIsp = True
+		}
 		atmosphereCurve
 		{
-			key = 0 57
-			key = 1 26
+			key = 0 140
+			key = 1 90
 		}
 	}
 
@@ -111,19 +124,44 @@ PART
 }
 @PART[ROE-Antares3_Inline]:AFTER[RealismOverhaulEngines]
 {
-	@mass += 0.03	//Add mass of RCS system
+	@mass += 0.036	//Add mass of RCS system
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		@origMass += 0.036
+	}
+
+	//Remove MFT and just put the propellant in a stock tank so we can use the tank for RCS
+	!MODULE[ModuleFuelTanks] {}
+
+	RESOURCE
+	{
+		name = HTPB
+		amount = 726.516
+		maxAmount = 726.516
+	}
+
+	//Source: https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2401&context=smallsat
+	//counting pixels, Scout 3rd stage contains 2 spherical tanks with a radius of ~0.1 meters
+	//Total volume ~8.5 liters
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 20
+		volume = 8.5
 		type = ServiceModule
 		basemass = -1
-
+		
 		TANK
 		{
-			name = Nitrogen
-			amount = 4000
-			maxAmount = 4000
+			name = HTP
+			amount = 8.04733727810651
+			maxAmount = 8.04733727810651
+		}
+		TANK
+		{
+			name = Helium
+			amount = 90.5325443786982
+			maxAmount = 90.5325443786982
 		}
 	}
 }

--- a/GameData/ROEngines/PartConfigs/Castor1_Inline_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/Castor1_Inline_BDB.cfg
@@ -74,14 +74,27 @@ PART
 		name = ModuleRCSFX
 		stagingEnabled = True
 		thrusterTransformName = rcsTransform
-		thrusterPower = 0.5
-		resourceName = Nitrogen
+		thrusterPower = 2.22
+		//500 lbf pitch/yaw thrusters , 40 lbf roll thrusters source:https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2401&context=smallsat
+		resourceName = HTP
 		resourceFlowMode = STACK_PRIORITY_SEARCH
 		runningEffectName = control
+		PROPELLANT
+		{
+			ratio = 1.0
+			name = HTP
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 11.25
+			ignoreForIsp = True
+		}
 		atmosphereCurve
 		{
-			key = 0 57
-			key = 1 26
+			key = 0 140	//RPA numbers
+			key = 1 90
 		}
 	}
 
@@ -117,19 +130,43 @@ PART
 }
 @PART[ROE-Castor1_Inline]:AFTER[RealismOverhaulEngines]
 {
-	@mass += 0.05	//Add mass of RCS system
+	@mass += 0.07	//Add mass of RCS system
 
+	@MODULE[ModuleEngineConfigs]
+	{
+		@origMass += 0.07
+	}
+
+	//Remove MFT and just put the propellant in a stock tank so we can use the tank for RCS
+	!MODULE[ModuleFuelTanks] {}
+
+	RESOURCE
+	{
+		name = PSPC
+		amount = 1909
+		maxAmount = 1909
+	}
+
+	//Source: https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2401&context=smallsat
+	//counting pixels, Scout 2nd stage contains 12 spherical tanks (10 HTP 2 Gas) with a radius of ~0.1 meters
+	//Total volume ~51 liters
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 100
+		volume = 51
 		type = ServiceModule
 		basemass = -1
 		TANK
 		{
-			name = Nitrogen
-			amount = 20000
-			maxAmount = 20000
+			name = HTP
+			amount = 48.2840236686391
+			maxAmount = 48.2840236686391
+		}
+		TANK
+		{
+			name = Helium
+			amount = 543.195266272189
+			maxAmount = 543.195266272189
 		}
 	}
 }

--- a/GameData/ROEngines/PartConfigs/Castor2_Inline_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/Castor2_Inline_BDB.cfg
@@ -74,14 +74,27 @@ PART
 		name = ModuleRCSFX
 		stagingEnabled = True
 		thrusterTransformName = rcsTransform
-		thrusterPower = 0.5
-		resourceName = Nitrogen
+		thrusterPower = 2.22
+		//500 lbf pitch/yaw thrusters , 40 lbf roll thrusters source:https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2401&context=smallsat
+		resourceName = HTP
 		resourceFlowMode = STACK_PRIORITY_SEARCH
 		runningEffectName = control
+		PROPELLANT
+		{
+			ratio = 1.0
+			name = HTP
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 11.25
+			ignoreForIsp = True
+		}
 		atmosphereCurve
 		{
-			key = 0 57
-			key = 1 26
+			key = 0 140
+			key = 1 90
 		}
 	}
 
@@ -117,18 +130,43 @@ PART
 }
 @PART[ROE-Castor2_Inline]:AFTER[RealismOverhaulEngines]
 {
-	@mass += 0.05	//Add mass of RCS system
+	@mass += 0.07	//Add mass of RCS system
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		@origMass += 0.07
+	}
+
+	//Remove MFT and just put the propellant in a stock tank so we can use the tank for RCS
+	!MODULE[ModuleFuelTanks] {}
+
+	RESOURCE
+	{
+		name = PBAA
+		amount = 2101.574494
+		maxAmount = 2101.574494
+	}
+
+	//Source: https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2401&context=smallsat
+	//counting pixels, Scout 2nd stage contains 12 spherical tanks (10 HTP 2 Gas) with a radius of ~0.1 meters
+	//Total volume ~51 liters
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 100
+		volume = 51
 		type = ServiceModule
 		basemass = -1
 		TANK
 		{
-			name = Nitrogen
-			amount = 20000
-			maxAmount = 20000
+			name = HTP
+			amount = 48.2840236686391
+			maxAmount = 48.2840236686391
+		}
+		TANK
+		{
+			name = Helium
+			amount = 543.195266272189
+			maxAmount = 543.195266272189
 		}
 	}
 }

--- a/GameData/ROEngines/Waterfall/SRM/Algols.cfg
+++ b/GameData/ROEngines/Waterfall/SRM/Algols.cfg
@@ -24,3 +24,30 @@
         glow = ro-srm
     }
 }
+
+@PART[ROE-Algol3]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0.225
+        rotation = 0, 0, 0
+        scale = 1.25, 1.46, 1.46
+        glow = ro-srm
+    }
+}
+@PART[ROE-Algol3_Inline]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 1.25, 1.42, 1.46
+        glow = ro-srm
+    }
+}


### PR DESCRIPTION
Based on https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2401&context=smallsat, correct Scout RCS performance (on Castor and Antares), and add Algol III.

Needs https://github.com/KSP-RO/RP-0/pull/1857
Needs https://github.com/KSP-RO/RealismOverhaul/pull/2760