### PR TITLE
Fix/Improve Agena Equipment Rack

### DIFF
--- a/GameData/ROEngines/PartConfigs/Agena_EquipmentRack_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/Agena_EquipmentRack_BDB.cfg
@@ -60,7 +60,7 @@ PART
 
 	tags = agena, agena-a, a, agena-b, b, agena-d, d, bell, equipment, rcs
 
-	mass = 0.102
+	mass = 0.017
 
 	//Use generic RCS configs
 	useRcsConfig = RCSBlockTenth
@@ -108,8 +108,8 @@ PART
 	{
 		name = ModuleFuelTanks
 		volume = 90	//Include space for batteries
-		basemass = -1
-		type = Fuselage
+		basemass = 0.017
+		type = SM-III	//Gemini-era
 		TANK
 		{
 			name = ElectricCharge

--- a/GameData/ROEngines/PartConfigs/Agena_SPS_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/Agena_SPS_BDB.cfg
@@ -220,3 +220,37 @@ PART
 		}
 	}
 }
+
+//waterfall clobbers our RCS effects while adding the main engine effects. Go and replace it afterwards.
+@PART[ROE-AgenaSPS]:AFTER[Waterfall]
+{
+	@EFFECTS
+	{
+		runningRCS
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_rocket_mini
+				volume = 0.0 0.0
+				volume = 0.1 0.0
+				volume = 0.5 0.05
+				volume = 1.0 0.5
+				pitch = 0.0 0.5
+				pitch = 1.0 1.0
+				loop = true
+			}
+			MODEL_MULTI_PARTICLE
+			{
+				modelName = Squad/FX/Monoprop_small
+				transformName = rcsTransform
+				emission = 0.0 0.0
+				emission = 0.1 0.0
+				emission = 1.0 1.0
+				speed = 0.0 0.8
+				speed = 1.0 1.0
+				localRotation = -90, 0, 0
+			}
+		}
+	}
+}


### PR DESCRIPTION
Change Agena Equipment rack to use SM-III tanks (so you can no longer get massless batteries), and fix the RCS plume on the Agena SPS.