### PR TITLE
Fix Agena SPS thrust

### DIFF
--- a/GameData/ROEngines/PartConfigs/Agena_SPS_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/Agena_SPS_BDB.cfg
@@ -220,3 +220,17 @@ PART
 		}
 	}
 }
+//using RCSBlockTenth also effects the main engine config, reducing thrust and mass
+//since I don't want to mess with the Generic RCS config, just manually set everything back afterwards
+@PART[ROE-AgenaSPS]:AFTER[RealismOverhaulEngines]
+{
+	@MODULE[ModuleEngineConfigs],0
+	{
+		@origMass *= 3.1623
+		@CONFIG,*
+		{
+			@maxThrust *= 10
+			@minThrust *= 10
+		}
+	}
+}


### PR DESCRIPTION
Using both an engine config and generic RCS on the same part seems to cause some unexpected issues, as the modifiers for the RCS also applies to the engine config. Since I don't wanna mess with the RCS patches, just manually set the engine config back to the correct value.