### PR TITLE
Alternate RD-0105 model

### DIFF
--- a/GameData/ROEngines/PartConfigs/RD0105_RE.cfg
+++ b/GameData/ROEngines/PartConfigs/RD0105_RE.cfg
@@ -65,3 +65,87 @@ PART
 		thrustTransformName = thrustTransform
 	}
 }
+
++PART[ROE-RD0105]:FINAL
+{
+	@name = ROE-RD0105-Alt
+
+	@MODEL {
+		// use alternate model; main difference is much longer vernier arms
+		// but it seems subtly different in other ways that look nicer
+		@model = ROEngines/Assets/RealEngines/RD0105_Pap - Blowfish
+		@scale = 1, 1, 1
+	}
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = squishIt
+		SUBTYPE
+		{
+			name = Default
+			TRANSFORM
+			{
+				// nozzle is too tall; shrink it, keeping its bottom in place so
+				// it stays flush with the collider bottom (and where the plume is)
+				// Also fix its weird slightly-oval shape
+				name = Nozzle
+				scaleOffset = 1.06, 0.7, 1.0
+				positionOffset = 0, -0.23, 0
+			}
+			TRANSFORM
+			{
+				// bring plumbing down to follow the nozzle. stretch it a bit so its top
+				// doesn't get TOO far from the collider top
+				name = Plumbing
+				scaleOffset = 1.0, 1.1, 1.0
+				positionOffset = 0, -0.35, 0
+			}
+			TRANSFORM
+			{
+				// make cap thinner; on photos it looks like a sheet, not a slab.
+				// and again bring it down to follow the nozzle
+				name = Cap
+				positionOffset = 0, -0.15, 0
+				scaleOffset = 1, 0.5, 1
+			}
+			TRANSFORM
+			{
+				// bring pipes down to stay flush with cap; enlarge them so the verniers
+				// end up outside Blok E's diameter (even the alternate model is still too
+				// narrow).
+				name = VernierPipe
+				positionOffset = 0, -0.17, 0
+				scaleOffset = 1.15, 1.15, 1.15
+			}
+			TRANSFORM
+			{
+				// vernier is a subtransform of pipes, so position is right but they got
+				// enlarged; shrink them back down. and pull them up a touch; pipes don't
+				// curve back up as much as they should
+				name = VernierNozzle
+				scaleOffset = 0.6, 0.6, 0.6
+				positionOffset = 0, 0, -0.01
+			}
+		}
+	}
+	// and then move the nodes to where the model ended up
+	@node_stack_top = 0.0, 0.53, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_center = 0.0, -0.14, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -0.79, 0.0, 0.0, -1.0, 0.0, 1
+	@node_attach = 0.0, 0.53, 0.0, 0.0, 1.0, 0.0, 0
+
+
+	// Photos suggest the verniers didn't gimbal; they were angled inwards and achieved
+	// attitude control through differential thrust, plus some extra nozzles for roll
+	// control. We can't do that without turning them into weird rcs like rd-109; just
+	// limit them to gimballing inwards with a wide range.
+	// Plus a tiny bit of side range for roll control.
+	// http://www.russianspaceweb.com/images/rockets/vostok/block_e_nozzle_1.jpg
+	@MODULE[ModuleGimbal] {
+		!gimbalRange = delete
+		gimbalRangeXP = 2
+		gimbalRangeXN = 2
+		gimbalRangeYP = 0
+		gimbalRangeYN = 45
+	}
+}


### PR DESCRIPTION
Using the "blowfish" model that existed all along but wasn't used; plus some b9ps magic to tweak the proportions and maybe get closer to the real thing. Biggest differences are a nozzle that doesn't stick out of the cap so much, and a wider vernier spread.

Also a different approach to attitude control, possibly closer to reality

As a separate part, because I see no way to make it a switchable variant; the two models use the same transform names.

Probably not for merging as-is, uses `:FINAL` as a shortcut to inherit the RO and RP-1 bits. Will clean up if this garners interest.

current part:
<img width="698" alt="Screenshot 2023-05-16 at 18 20 31" src="https://github.com/KSP-RO/ROEngines/assets/5061230/5f155967-4d38-4eb9-98c3-42fb1603f8eb">


this part:
<img width="963" alt="Screenshot 2023-05-16 at 18 20 14" src="https://github.com/KSP-RO/ROEngines/assets/5061230/a02433b7-56d0-4cec-9695-a6bd1dfa72fb">
