### PR TITLE
RD-270 scale adjustment

### DIFF
--- a/GameData/ROEngines/PartConfigs/RD270_CH4.cfg
+++ b/GameData/ROEngines/PartConfigs/RD270_CH4.cfg
@@ -9,15 +9,15 @@ PART
 	MODEL
 	{
 		model = ROEngines/Assets/TheBeastlyPig/RD270
-		scale = 0.73, 0.77472644, 0.73
+		scale = 1.0, 1.0613, 1.0
 	}
 
 	scale = 1.0
-	rescaleFactor = 0.81182846
+	rescaleFactor = 0.5926
 
-	node_stack_top = 0.0, 3.9797591, 0.0, 0.0, 1.0, 0.0, 3
-	node_stack_bottom = 0.0, -1.9102844, 0.0, 0.0, -1.0, 0.0, 3
-	node_attach = 0.0, 3.9797591, 0.0, 0.0, 1.0, 0.0
+	node_stack_top = 0.0, 5.4843, 0.0, 0.0, 1.0, 0.0, 3
+	node_stack_bottom = 0.0, -2.6156, 0.0, 0.0, -1.0, 0.0, 3
+	node_attach = 0.0, 5.4843, 0.0, 0.0, 1.0, 0.0
 	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,1,0
 	

--- a/GameData/ROEngines/PartConfigs/RD270_CH4.cfg
+++ b/GameData/ROEngines/PartConfigs/RD270_CH4.cfg
@@ -13,7 +13,7 @@ PART
 	}
 
 	scale = 1.0
-	rescaleFactor = 1.13
+	rescaleFactor = 0.81182846
 
 	node_stack_top = 0.0, 3.75, 0.0, 0.0, 1.0, 0.0, 3
 	node_stack_bottom = 0.0, -1.8, 0.0, 0.0, -1.0, 0.0, 3

--- a/GameData/ROEngines/PartConfigs/RD270_CH4.cfg
+++ b/GameData/ROEngines/PartConfigs/RD270_CH4.cfg
@@ -9,7 +9,7 @@ PART
 	MODEL
 	{
 		model = ROEngines/Assets/TheBeastlyPig/RD270
-		scale = 0.73, 0.73, 0.73
+		scale = 0.73, 0.77472644, 0.73
 	}
 
 	scale = 1.0
@@ -17,7 +17,7 @@ PART
 
 	node_stack_top = 0.0, 3.75, 0.0, 0.0, 1.0, 0.0, 3
 	node_stack_bottom = 0.0, -1.8, 0.0, 0.0, -1.0, 0.0, 3
-	node_attach = 0.0, 3.75, 0.0, 0.0, 1.0, 0.0
+	node_attach = 0.0, 3.9797591, 0.0, 0.0, 1.0, 0.0
 	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,1,0
 	

--- a/GameData/ROEngines/PartConfigs/RD270_CH4.cfg
+++ b/GameData/ROEngines/PartConfigs/RD270_CH4.cfg
@@ -15,8 +15,8 @@ PART
 	scale = 1.0
 	rescaleFactor = 0.81182846
 
-	node_stack_top = 0.0, 3.75, 0.0, 0.0, 1.0, 0.0, 3
-	node_stack_bottom = 0.0, -1.8, 0.0, 0.0, -1.0, 0.0, 3
+	node_stack_top = 0.0, 3.9797591, 0.0, 0.0, 1.0, 0.0, 3
+	node_stack_bottom = 0.0, -1.9102844, 0.0, 0.0, -1.0, 0.0, 3
 	node_attach = 0.0, 3.9797591, 0.0, 0.0, 1.0, 0.0
 	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,1,0

--- a/GameData/ROEngines/Waterfall/Borane/RD-270M.cfg
+++ b/GameData/ROEngines/Waterfall/Borane/RD-270M.cfg
@@ -6,14 +6,14 @@
         audio = pump-fed-heavy-1
         position = 0,0,0.44
         rotation = 0, 0, 0
-        scale = 2.9, 2.9, 2.9
+        scale = 2.2, 2.2, 2.2
 
         ExtraTemplate
         {
             template = rowaterfall-glow-pentaborane
             position = 0,0,0.42
             rotation = 0, 0, 0
-            scale = 2.79, 2.79, 5.9
+            scale = 2.04, 2.04, 4.3
         }
     }
 }

--- a/GameData/ROEngines/Waterfall/Hypergolic/RD-270.cfg
+++ b/GameData/ROEngines/Waterfall/Hypergolic/RD-270.cfg
@@ -6,7 +6,7 @@
         audio = pump-fed-heavy-1
         position = 0,0,0.43
         rotation = 0, 0, 0
-        scale = 2.85, 2.85, 2.85
+        scale = 2.1, 2.2, 2.2
         glow = _white
     }
 }


### PR DESCRIPTION
Scaled according to [1969-07-29](http://epizodyspace.ru/bibl/glushko/izbran-rab-glushko/1/04.html), 2.37m nozzle diameter, 4.85m height. Either the version being discussed in that letter has a shorter nozzle than what the model is based on, or the model is slightly off, so the vertical scale had to be changed as well as rescaleFactor.

If the non-uniform scaling is an issue, `rescaleFactor = 0.86156846` with `scale = 0.73, 0.73, 0.73` should at least have the 4.85m height be correct and the nozzle only slightly too wide. Uniform scaling with `rescaleFactor = 0.81182846` results in a 4.57m height.

Relative node positioning _should_ be unchanged (note that the top node is currently slightly below the top of the nozzle) but I've tried changing node positions by scale change factors in the past and it never quite seemed to line up; though having tested it, the bottom node is at least where it should be (or very, very close) and the top node _seems_ no further into the model than it was before.