### PR TITLE
Add alternate Verniers to RD0105

### DIFF
--- a/GameData/ROEngines/Compatibility/ROE-TexturesUnlimited.cfg
+++ b/GameData/ROEngines/Compatibility/ROE-TexturesUnlimited.cfg
@@ -437,6 +437,7 @@ KSP_MODEL_SHADER
 	model = ROEngines/Assets/RealEngines/A7
 	model = ROEngines/Assets/RealEngines/AJ10_190
 	model = ROEngines/Assets/RealEngines/RD0105_Pap
+	model = ROEngines/Assets/RealEngines/RD0105_Pap - Blowfish
 	model = ROEngines/Assets/RealEngines/LMAE
 	model = ROEngines/Assets/RealEngines/LMDE
 	model = ROEngines/Assets/RealEngines/NK33

--- a/GameData/ROEngines/PartConfigs/RD0105_RE.cfg
+++ b/GameData/ROEngines/PartConfigs/RD0105_RE.cfg
@@ -15,6 +15,11 @@ PART
 		model = ROEngines/Assets/RealEngines/RD0105_Pap
 		scale = 1.0, 1.0, 1.0
 	}
+	MODEL
+	{
+		model = ROEngines/Assets/RealEngines/RD0105_Pap - Blowfish
+		scale = 1.0, 1.0, 1.0
+	}
 
 	scale = 1.0
 	rescaleFactor = 1.0
@@ -46,6 +51,26 @@ PART
 		{
 			name = vernierTransform
 			overallMultiplier = 0.0042
+		}
+	}
+	
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = vernier
+		switcherDescription = Vernier
+		switcherDescriptionPlural = Verniers
+		affectDragCubes = True
+		affectFARVoxels = True
+		SUBTYPE
+		{
+			name = Compact
+			transform = ROEngines/Assets/RealEngines/RD0105_Pap(Clone)
+		}
+		SUBTYPE
+		{
+			name = Wide
+			transform = ROEngines/Assets/RealEngines/RD0105_Pap - Blowfish(Clone)
 		}
 	}
 


### PR DESCRIPTION
Use B9PS to allow selection of previously unused RD0105 model with wider vernier layout