### PR TITLE
Add X-405H-2 Nozzle switching

### DIFF
--- a/GameData/ROEngines/PartConfigs/X405H_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/X405H_BDB.cfg
@@ -212,6 +212,7 @@ PART
 		@configuration = X-405H
 		!CONFIG[X-405] {}
 		@CONFIG[X-405H] { %LinkB9PSModule[nozzle] { %subtype = base }}
+  		@CONFIG[X-405H-2] { %LinkB9PSModule[nozzle] { %subtype = base }}
 		@CONFIG[X-405H-3] { %LinkB9PSModule[nozzle] { %subtype = upgraded }}
 		@CONFIG[X-405H-4] { %LinkB9PSModule[nozzle] { %subtype = upgraded }}
 	}


### PR DESCRIPTION
Fixes the case where a config with the upgraded nozzle is selected, then the H-2, leaving the H-2 with the wrong model