### PR TITLE
Better restock support in ModularRCS

### DIFF
--- a/GameData/ROEngines/Data/Models/ModelData-RCS-ReStock.cfg
+++ b/GameData/ROEngines/Data/Models/ModelData-RCS-ReStock.cfg
@@ -21,7 +21,6 @@ ROL_MODEL:NEEDS[ReStock]
 	{
 		thrustTransformName = RCSjet
 		nozzles = 4
-		modelScale = 0.533333
 		thrustTransformPositionOffset = 0, 0.025, 0
 		thrustTransformScaleOffset = 0.77
 	}
@@ -49,7 +48,6 @@ ROL_MODEL:NEEDS[ReStock]
 	{
 		thrustTransformName = RCSjet
 		nozzles = 5
-		modelScale = 0.533333
 		thrustTransformPositionOffset = 0, 0.025, 0
 		thrustTransformScaleOffset = 0.77
 	}
@@ -77,7 +75,6 @@ ROL_MODEL:NEEDS[ReStock]
 	{
 		thrustTransformName = RCSjet
 		nozzles = 4
-		modelScale = 0.533333
 		thrustTransformPositionOffset = 0, 0.025, 0
 		thrustTransformScaleOffset = 0.77
 	}
@@ -105,7 +102,6 @@ ROL_MODEL:NEEDS[ReStock]
 	{
 		thrustTransformName = RCSjet
 		nozzles = 3
-		modelScale = 0.533333
 		thrustTransformPositionOffset = 0, 0.025, 0
 		thrustTransformScaleOffset = 0.77
 	}
@@ -133,7 +129,6 @@ ROL_MODEL:NEEDS[ReStock]
 	{
 		thrustTransformName = RCSjet
 		nozzles = 2
-		modelScale = 0.533333
 		thrustTransformPositionOffset = 0, 0.025, 0
 		thrustTransformScaleOffset = 0.77
 	}
@@ -149,6 +144,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
+	scaleOffset = 2,2,2
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -163,7 +159,6 @@ ROL_MODEL:NEEDS[ReStock]
 	{
 		thrustTransformName = RCSjet
 		nozzles = 4
-		modelScale = 0.207
 		thrustTransformScaleOffset = 0.25
 	}
 }
@@ -176,6 +171,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
+	scaleOffset = 2,2,2
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -190,7 +186,6 @@ ROL_MODEL:NEEDS[ReStock]
 	{
 		thrustTransformName = RCSjet
 		nozzles = 5
-		modelScale = 0.207
 		thrustTransformScaleOffset = 0.25
 	}
 }
@@ -203,6 +198,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
+	scaleOffset = 2,2,2
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -217,7 +213,6 @@ ROL_MODEL:NEEDS[ReStock]
 	{
 		thrustTransformName = RCSjet
 		nozzles = 4
-		modelScale = 0.207
 		thrustTransformScaleOffset = 0.25
 	}
 }
@@ -230,6 +225,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
+	scaleOffset = 2,2,2
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -244,7 +240,6 @@ ROL_MODEL:NEEDS[ReStock]
 	{
 		thrustTransformName = RCSjet
 		nozzles = 3
-		modelScale = 0.207
 		thrustTransformScaleOffset = 0.25
 	}
 }
@@ -257,6 +252,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
+	scaleOffset = 2,2,2
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -271,7 +267,6 @@ ROL_MODEL:NEEDS[ReStock]
 	{
 		thrustTransformName = RCSjet
 		nozzles = 2
-		modelScale = 0.207
 		thrustTransformScaleOffset = 0.25
 	}
 }
@@ -298,7 +293,6 @@ ROL_MODEL:NEEDS[ReStock]
 	{
 		thrustTransformName = RCSthruster
 		nozzles = 1
-		modelScale = 0.533333
 		thrustTransformScaleOffset = 0.82
 	}
 }
@@ -322,7 +316,6 @@ ROL_MODEL:NEEDS[ReStock]
 	RCSDATA	{
 		thrustTransformName = RCSthruster
 		nozzles = 1
-		modelScale = 0.533333
 		thrustTransformScaleOffset = 0.82
 	}
 }
@@ -335,6 +328,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
+	scaleOffset = 2,2,2
 	surface = -0,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -346,9 +340,8 @@ ROL_MODEL:NEEDS[ReStock]
 	{
 		thrustTransformName = RCSthruster
 		nozzles = 1
-		modelScale = 0.256
 		thrustTransformScaleOffset = 0.3
-		thrustTransformPositionOffset = 0, 0.07, 0
+		thrustTransformPositionOffset = 0, 0.15, 0
 	}
 }
 ROL_MODEL:NEEDS[ReStock]
@@ -360,6 +353,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
+	scaleOffset = 2,2,2
 	surface = -0,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -371,9 +365,8 @@ ROL_MODEL:NEEDS[ReStock]
 	{
 		thrustTransformName = RCSthruster
 		nozzles = 1
-		modelScale = 0.256
 		thrustTransformScaleOffset = 0.3
-		thrustTransformPositionOffset = 0, 0.07, 0
+		thrustTransformPositionOffset = 0, 0.15, 0
 	}
 }
 
@@ -396,6 +389,111 @@ ROL_MODEL:NEEDS[ReStock]
 	{
 		thrustTransformName = RCSthruster
 		nozzles = 1
-		modelScale = 0.3
 	}
 }
+
+
+//// 45-degree-angles, stock-style
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	// 4-Way
+	name = RCS-ReStock-45-4x
+	title = ReStock 45
+	modelName = ReStock/Assets/Control/restock-rcs-block-multi-2
+	orientation = TOP
+	positionOffset = 0,0,0
+	rotationOffset = 0,0,0
+	surface = -0.05,0,0,-1,0,0
+	diameter = 0.234
+	height = 0
+	volume = 0
+	disableTransform = B_RCS2x
+	disableTransform = B_RCS3x
+	//disableTransform = B_RCS4x
+	disableTransform = B_RCS5x
+	depthMask = RCSMask
+	RCSDATA
+	{
+		thrustTransformName = RCSthruster
+		nozzles = 4
+		thrustTransformScaleOffset = 0.77
+		thrustTransformPositionOffset = 0, 0.1, 0
+	}
+}
++ROL_MODEL[RCS-ReStock-45-4x]
+{
+	@name = RCS-ReStock-45-5x
+	@disableTransform,* ^= :RCS5x:RCS4x:
+	@RCSDATA
+	{
+		@nozzles = 5
+	}
+}
++ROL_MODEL[RCS-ReStock-45-4x]
+{
+	@name = RCS-ReStock-45-3x
+	@disableTransform,* ^= :RCS3x:RCS4x:
+	@RCSDATA
+	{
+		@nozzles = 3
+	}
+}
++ROL_MODEL[RCS-ReStock-45-4x]
+{
+	@name = RCS-ReStock-45-2x
+	@disableTransform,* ^= :RCS2x:RCS4x:
+	@RCSDATA
+	{
+		@nozzles = 2
+	}
+}
+
+//// 45-degree-angles, Mini-style
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	// 4-Way
+	name = RCS-ReStock-45-4x-Mini
+	title = ReStock 45 Mini
+	modelName = ReStock/Assets/Control/restock-rcs-block-multi-mini-2
+	orientation = TOP
+	positionOffset = 0,0,0
+	rotationOffset = 0,0,0
+	scaleOffset = 2,2,2
+	surface = -0.05,0,0,-1,0,0
+	diameter = 0.234
+	height = 0
+	volume = 0
+	disableTransform = B_RCS2x
+	disableTransform = B_RCS3x
+	//disableTransform = B_RCS4x
+	disableTransform = B_RCS5x
+	depthMask = RCSMask
+	RCSDATA
+	{
+		thrustTransformName = RCSthruster
+		nozzles = 4
+		thrustTransformScaleOffset = 0.25
+		thrustTransformPositionOffset = 0, 0.085, 0
+	}
+}
++ROL_MODEL[RCS-ReStock-45-4x-Mini]
+{
+	@name = RCS-ReStock-45-3x-Mini
+	@disableTransform,* ^= :RCS3x:RCS4x:
+	@RCSDATA
+	{
+		@nozzles = 3
+	}
+}
++ROL_MODEL[RCS-ReStock-45-4x-Mini]
+{
+	@name = RCS-ReStock-45-2x-Mini
+	@disableTransform,* ^= :RCS2x:RCS4x:
+	@RCSDATA
+	{
+		@nozzles = 2
+	}
+}
+

--- a/GameData/ROEngines/PartConfigs/RCS/ReStock-Parts.cfg
+++ b/GameData/ROEngines/PartConfigs/RCS/ReStock-Parts.cfg
@@ -14,11 +14,15 @@
 		{
 			model = RCS-ReStock-2
 			model = RCS-ReStock-2-Mini
+			model = RCS-ReStock-45-2x
+			model = RCS-ReStock-45-2x-Mini
 		}
 		@RCSMODEL:HAS[#variant[3*]]
 		{
 			model = RCS-ReStock-3
 			model = RCS-ReStock-3-Mini
+			model = RCS-ReStock-45-3x
+			model = RCS-ReStock-45-3x-Mini
 		}
 		@RCSMODEL:HAS[#variant[4*]]
 		{
@@ -26,11 +30,14 @@
 			model = RCS-ReStock-4-Mini
 			model = RCS-ReStock-4A
 			model = RCS-ReStock-4A-Mini
+			model = RCS-ReStock-45-4x
+			model = RCS-ReStock-45-4x-Mini
 		}
 		@RCSMODEL:HAS[#variant[5*]]
 		{
 			model = RCS-ReStock-5
 			model = RCS-ReStock-5-Mini
+			model = RCS-ReStock-45-5x
 		}
 	}
 }


### PR DESCRIPTION
- fix the -mini thruster scaling; modelScale isn't a thing. 2x is a bit small, but good enough; they _are_ called "mini"
- add 45-degree variants