### PR TITLE
Partial fix for SIVB APS 500

### DIFF
--- a/GameData/ROEngines/Data/Models/ModelData-RCS-BDB.cfg
+++ b/GameData/ROEngines/Data/Models/ModelData-RCS-BDB.cfg
@@ -857,7 +857,7 @@ ROL_MODEL
 
 ROL_MODEL
 {
-	// 4-Way
+	// 3-Way
 	name = RCS-BDB-Saturn-200
 	title = BDB SIVB APS 200
 	modelName = ROEngines/Assets/BDB/RCS/bluedog_Saturn_S4B_APS_200
@@ -872,7 +872,7 @@ ROL_MODEL
 	RCSDATA
 	{
 		thrustTransformName = rcsTransform
-		nozzles = 4
+		nozzles = 3
 		thrustTransformScaleOffset = 0.8
 	}
 }
@@ -892,8 +892,11 @@ ROL_MODEL
 	volume = 0
 	RCSDATA
 	{
-		thrustTransformName = rcsTransform
-		nozzles = 4
+		thrustTransformName = rcsTransform_yaw
+                // FIXME: ModelRCSModuleData only supports one thrustTransform?
+		//thrustTransformName = rcsTransform_ullage
+		//nozzles = 4
+		nozzles = 3
 		thrustTransformScaleOffset = 0.7
 	}
 }

--- a/GameData/ROEngines/PartConfigs/RCS/ROE-ModularRCS.cfg
+++ b/GameData/ROEngines/PartConfigs/RCS/ROE-ModularRCS.cfg
@@ -136,6 +136,7 @@ PART
 			model = RCS-BDB-Probe-3-45
 			model = RCS-BDB-Probe-3
 			model = RCS-BDB-Probe-3-Radial
+			model = RCS-BDB-Saturn-200
 			model = RCS-BDB-Skylab-ACS
 			model = RCS-BDB-Titan-3-Radial			
 			model = RCS-4F-T
@@ -152,7 +153,6 @@ PART
 			model = RCS-BDB-Gemini-Ferry
 			model = RCS-BDB-Probe-4-45
 			model = RCS-BDB-Probe-4
-			model = RCS-BDB-Saturn-200
 			model = RCS-BDB-Saturn-500
 			model = RCS-BDB-Titan-4
 			model = RCS-Vens-Heavy


### PR DESCRIPTION
"rcsTransform" doesn't exist. There are two transforms, one for pitch/yaw, one for fore; ModularRCS doesn't appear to support multiple tranforms, so pick the most useful one.

Partially fixes #208

Also move APS 200 into the 3-way section, since that one really is meant to be a 3-way (no fore)