### PR TITLE
Move RCS-BDB-Titan-23G to the right category

### DIFF
--- a/GameData/ROEngines/PartConfigs/RCS/ROE-ModularRCS.cfg
+++ b/GameData/ROEngines/PartConfigs/RCS/ROE-ModularRCS.cfg
@@ -116,7 +116,6 @@ PART
 			model = RCS-BDB-Probe-2-Vertical
 			model = RCS-BDB-Redstone
 			model = RCS-BDB-Titan-2-Radial
-			model = RCS-BDB-Titan-23G			
 			model = RCS-4A-V2
 		}
 		
@@ -138,6 +137,7 @@ PART
 			model = RCS-BDB-Probe-3-Radial
 			model = RCS-BDB-Saturn-200
 			model = RCS-BDB-Skylab-ACS
+			model = RCS-BDB-Titan-23G			
 			model = RCS-BDB-Titan-3-Radial			
 			model = RCS-4F-T
 			model = RCS-6A-T


### PR DESCRIPTION
It's a 3-way, not a 2-way. The ROL_MODEL is correct, it's just in the wrong PAW group