### PR TITLE
Deprecate RD-0110 Vernier

### DIFF
--- a/GameData/ROEngines/PartConfigs/RD0110_Vernier_RE.cfg
+++ b/GameData/ROEngines/PartConfigs/RD0110_Vernier_RE.cfg
@@ -5,6 +5,7 @@ PART
 	author = Alcentar, Pap
 
 	ROESetEngineDefaults = LIQUID_ENGINE
+	RODeprecated = true
 
 	//  ============================================================================
 	//	Update Below


### PR DESCRIPTION
Unlike the LR101 or RD-0214, these verniers were just the gas generator exhaust of the RD-0110 and really shouldn't be able to function independently. Since we don't even provide a vernier-less RD-0110 model to pair them with, deprecate them