### PR TITLE
Modular Resistojets

### DIFF
--- a/GameData/ROEngines/PartConfigs/RCS/ROE-ModularRCS.cfg
+++ b/GameData/ROEngines/PartConfigs/RCS/ROE-ModularRCS.cfg
@@ -228,3 +228,11 @@ PART
 		}
 	}
 }
+
++PART[ROE-ModularRCS]:BEFORE[RealismOverhaulEngines]
+{
+	@name = ROE-ModularResistojetRCS
+	@engineType = ElectricRCSGeneric
+	
+	@title = Modular Resistojet RCS
+}

--- a/GameData/ROEngines/Waterfall/Generic/ModularRCS.cfg
+++ b/GameData/ROEngines/Waterfall/Generic/ModularRCS.cfg
@@ -10,3 +10,16 @@
         scale = 1.1, 1.1, 1.1
     }
 }
+
+@PART[ROE-ModularResistojetRCS]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        autoConfig = rcs
+        transform = ROE-RCS-ThrustTransform
+        useRelativeScaling = true
+        position = 0,0,0
+        rotation = 180, 0, 0
+        scale = 1.1, 1.1, 1.1
+    }
+}


### PR DESCRIPTION
Clone modular RCS to create modular resistojet RCS. The models don't really match what real resistojets look like, but they're scaled more or less correctly and most of the resistojet bits are hidden inside the spacecraft anyway.

Needs https://github.com/KSP-RO/RealismOverhaul/pull/2985