### PR TITLE
Add B9PS/RF tank switching to Agena equipment rack

### DIFF
--- a/GameData/ROEngines/PartConfigs/Agena_EquipmentRack_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/Agena_EquipmentRack_BDB.cfg
@@ -118,11 +118,57 @@ PART
 		}
 	}
 
-	//Disable tank mesh switching, we can't adjust the fuel load in RF through it.
 	MODULE
 	{
-		name = ModuleB9DisableTransform
-		transform = Mesh_TwoBall
+		name = ModuleB9PartSwitch
+		moduleID = meshSwitchTanks
+		switcherDescription = Tanks
+		SUBTYPE
+		{
+			name = Three
+			title = Three RCS Tanks
+			transform = Mesh_ThreeBall
+			addedMass = 0
+			addedCost = 0
+			MODULE
+			{
+				IDENTIFIER { name = ModuleFuelTanks }
+				DATA
+				{
+					volume = 90
+					basemass = 0.017
+					TANK
+					{
+						name = ElectricCharge
+						amount = 42000
+						maxAmount = 42000
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Two
+			title = Two RCS Tanks
+			transform = Mesh_TwoBall
+			addedMass = -0.003
+			addedCost = -1
+			MODULE
+			{
+				IDENTIFIER { name = ModuleFuelTanks }
+				DATA
+				{
+					volume = 74
+					basemass = 0.014
+					TANK
+					{
+						name = ElectricCharge
+						amount = 42000
+						maxAmount = 42000
+					}
+				}
+			}
+		}
 	}
 
 	//Allow aft rack switching


### PR DESCRIPTION
Since B9PS/RF integration now works, restore tank switching options to the Agena equipment rack.