### PR TITLE
Fix Modular RCS Restock models scale

### DIFF
--- a/GameData/ROEngines/Data/Models/ModelData-RCS-ReStock.cfg
+++ b/GameData/ROEngines/Data/Models/ModelData-RCS-ReStock.cfg
@@ -7,6 +7,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
+	scaleOffset = 1.833,1.833,1.833
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -34,6 +35,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
+	scaleOffset = 1.833,1.833,1.833
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -61,6 +63,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
+	scaleOffset = 1.833,1.833,1.833
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -88,6 +91,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
+	scaleOffset = 1.833,1.833,1.833
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -115,6 +119,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
+	scaleOffset = 1.833,1.833,1.833
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -144,7 +149,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
-	scaleOffset = 2,2,2
+	scaleOffset = 3.257,3.257,3.257
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -171,7 +176,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
-	scaleOffset = 2,2,2
+	scaleOffset = 3.257,3.257,3.257
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -198,7 +203,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
-	scaleOffset = 2,2,2
+	scaleOffset = 3.257,3.257,3.257
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -225,7 +230,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
-	scaleOffset = 2,2,2
+	scaleOffset = 3.257,3.257,3.257
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -252,7 +257,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
-	scaleOffset = 2,2,2
+	scaleOffset = 3.257,3.257,3.257
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -281,6 +286,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,90
+	scaleOffset = 1.833,1.833,1.833
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -305,6 +311,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = -0.09,0,0
 	rotationOffset = 0,0,90
+	scaleOffset = 1.833,1.833,1.833
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -328,7 +335,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
-	scaleOffset = 2,2,2
+	scaleOffset = 3.257,3.257,3.257
 	surface = -0,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -353,7 +360,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
-	scaleOffset = 2,2,2
+	scaleOffset = 3.257,3.257,3.257
 	surface = -0,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -380,6 +387,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
+	scaleOffset = 0.667,0.667,0.667
 	surface = -0,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -404,6 +412,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
+	scaleOffset = 1.833,1.833,1.833
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0
@@ -460,7 +469,7 @@ ROL_MODEL:NEEDS[ReStock]
 	orientation = TOP
 	positionOffset = 0,0,0
 	rotationOffset = 0,0,0
-	scaleOffset = 2,2,2
+	scaleOffset = 3.257,3.257,3.257
 	surface = -0.05,0,0,-1,0,0
 	diameter = 0.234
 	height = 0


### PR DESCRIPTION
Changes the scale on the Restock models to be in line with all the other models. Mini ones are still a little bit smaller at 2/3 the nozzle diameter compared to the rest.