### PR TITLE
Disable blanket TU patches if Deferred is installed

### DIFF
--- a/GameData/ROEngines/Compatibility/ROE-TexturesUnlimited.cfg
+++ b/GameData/ROEngines/Compatibility/ROE-TexturesUnlimited.cfg
@@ -199,28 +199,12 @@ KSP_MODEL_SHADER:NEEDS[!zzz_Deferred]
 //	============================================================================
 //	All SSTU Engines
 //	============================================================================
-KSP_MODEL_SHADER:NEEDS[!zzz_Deferred]
+//These have native PBR, let them run even with deferred
+KSP_MODEL_SHADER
 {
 	name = ROE-SSTUEngines
-	//model = ROEngines/Assets/SSTU/SC-ENG-RL10B-2
-	model = ROEngines/Assets/SSTU/SC-ENG-RL10A-5
-	model = ROEngines/Assets/SSTU/SC-ENG-RL10A-4
-	model = ROEngines/Assets/SSTU/SC-ENG-RL10A-3
-	model = ROEngines/Assets/SSTU/SC-ENG-RL10C-Pap
-	model = ROEngines/Assets/SSTU/SC-ENG-RD-181
-	//model = ROEngines/Assets/SSTU/SC-ENG-RD-180
-	model = ROEngines/Assets/SSTU/SC-ENG-RD-171
-	model = ROEngines/Assets/SSTU/SC-ENG-RD-0110
-	model = ROEngines/Assets/SSTU/SC-ENG-RD-108A
-	model = ROEngines/Assets/SSTU/SC-ENG-RD-107A
-	model = ROEngines/Assets/SSTU/SC-ENG-J-2X
-	//model = ROEngines/Assets/SSTU/SC-ENG-J-2
-	//model = ROEngines/Assets/SSTU/SC-ENG-F1B
 	model = ROEngines/Assets/SSTU/SC-ENG-AJ10-190
-	//model = ROEngines/Assets/SSTU/SC-ENG-AJ10-137
-	model = ROEngines/Assets/SSTU/SC-ENG-LR-81-8096
-	model = ROEngines/Assets/SSTU/SC-ENG-LR-81-8048
-	//model = ROEngines/Assets/SSTU/SC-ENG-RS-68
+	model = ROEngines/Assets/SSTU/SC-ENG-J-2X
 	model = ROEngines/Assets/SSTU/SC-ENG-Merlin-1A
 	model = ROEngines/Assets/SSTU/SC-ENG-Merlin-1C
 	model = ROEngines/Assets/SSTU/SC-ENG-Merlin-1CV
@@ -237,7 +221,8 @@ KSP_MODEL_SHADER:NEEDS[!zzz_Deferred]
 //	============================================================================
 //	All SSTUKatniss Engines
 //	============================================================================
-KSP_MODEL_SHADER:NEEDS[!zzz_Deferred]
+//These have native PBR, let them run even with deferred
+KSP_MODEL_SHADER
 {
 	name = ROE-SSTUkatnissEngines
 	model = ROEngines/Assets/SSTUKatniss/SC-ENG-HG-3

--- a/GameData/ROEngines/Compatibility/ROE-TexturesUnlimited.cfg
+++ b/GameData/ROEngines/Compatibility/ROE-TexturesUnlimited.cfg
@@ -1,4 +1,4 @@
-@REFLECTION_CONFIG[default]:NEEDS[TexturesUnlimited]
+@REFLECTION_CONFIG[default]:NEEDS[TexturesUnlimited,!zzz_Deferred]
 {
 	@enabled = True
 }
@@ -6,7 +6,7 @@
 //	Catch All Config for all Metallic Engines
 //	For Generic, unpainted and polished metal
 //	============================================================================
-KSP_MODEL_SHADER
+KSP_MODEL_SHADER:NEEDS[!zzz_Deferred]
 {
 	name = ROE-MetallicEngines
 
@@ -157,7 +157,7 @@ KSP_MODEL_SHADER
 	}
 }
 
-+KSP_MODEL_SHADER[ROE-MetallicEngines]
++KSP_MODEL_SHADER[ROE-MetallicEngines]:NEEDS[!zzz_Deferred]
 {
 	@name = ROE-MetallicRD180
 
@@ -199,7 +199,7 @@ KSP_MODEL_SHADER
 //	============================================================================
 //	All SSTU Engines
 //	============================================================================
-KSP_MODEL_SHADER
+KSP_MODEL_SHADER:NEEDS[!zzz_Deferred]
 {
 	name = ROE-SSTUEngines
 	//model = ROEngines/Assets/SSTU/SC-ENG-RL10B-2
@@ -237,7 +237,7 @@ KSP_MODEL_SHADER
 //	============================================================================
 //	All SSTUKatniss Engines
 //	============================================================================
-KSP_MODEL_SHADER
+KSP_MODEL_SHADER:NEEDS[!zzz_Deferred]
 {
 	name = ROE-SSTUkatnissEngines
 	model = ROEngines/Assets/SSTUKatniss/SC-ENG-HG-3
@@ -259,7 +259,7 @@ KSP_MODEL_SHADER
 //	Catch All Config for all Solid Engines
 //	Generic metallic paint
 //	============================================================================
-KSP_MODEL_SHADER
+KSP_MODEL_SHADER:NEEDS[!zzz_Deferred]
 {
 	name = ROE-SolidEngines
 
@@ -352,7 +352,7 @@ KSP_MODEL_SHADER
 //	STAR motors
 //	For unpainted and polished metal
 //	============================================================================
-KSP_MODEL_SHADER
+KSP_MODEL_SHADER:NEEDS[!zzz_Deferred]
 {
 	name = ROE-MetallicStarMotors
 
@@ -402,7 +402,7 @@ KSP_MODEL_SHADER
 //	===========================================================================
 //	RD-100 and Variants
 //	===========================================================================
-KSP_MODEL_SHADER
+KSP_MODEL_SHADER:NEEDS[!zzz_Deferred]
 {
 	name = ROE-A4
 	model = ROEngines/Assets/RealEngines/RD_100
@@ -439,7 +439,7 @@ KSP_MODEL_SHADER
 //	A7 and RD-0105
 //	Anodized or painted metal
 //	===========================================================================
-KSP_MODEL_SHADER
+KSP_MODEL_SHADER:NEEDS[!zzz_Deferred]
 {
 	name = ROE-A7
 
@@ -547,7 +547,7 @@ KSP_MODEL_SHADER
 //	RS-68
 //	Anodized or painted metal
 //	===========================================================================
-KSP_MODEL_SHADER
+KSP_MODEL_SHADER:NEEDS[!zzz_Deferred]
 {
 	name = ROE-RS68
 


### PR DESCRIPTION
Since Deferred does an almost universally better job at choosing PBR metallic settings than the blanket TU patches, just disable them if Deferred is installed