### PR TITLE
Rename modular RCS to procedural RCS

### DIFF
--- a/GameData/ROEngines/PartConfigs/RCS/ROE-ModularRCS.cfg
+++ b/GameData/ROEngines/PartConfigs/RCS/ROE-ModularRCS.cfg
@@ -31,9 +31,9 @@ PART
 	//  Title, Description, Category, Techs
 	//  ============================================================================
 
-	title = Modular RCS
+	title = Procedural RCS
 	manufacturer = Generic
-	description = Modular RCS that can be configured with different RCS blocks as well as Base Structures to mount them to.
+	description = Procedural RCS that can be configured with different RCS blocks as well as Base Structures to mount them to.
 
 	tags = modular, proc, procedural, rcs, thruster, control
 


### PR DESCRIPTION
To make it line up with all other scalable parts in Procedural Tanks, and because the word "modular" doesn't really fit here (it's not a module of anything, and it's not a part that would snap to others of the same part somehow)

Should be done with https://github.com/KSP-RO/RP-1/pull/2481