### PR TITLE
Correct LR89-NA-5 Model

### DIFF
--- a/GameData/ROEngines/PartConfigs/LR89_BDB2.cfg
+++ b/GameData/ROEngines/PartConfigs/LR89_BDB2.cfg
@@ -240,10 +240,6 @@ PART
 		{
 			%LinkB9PSModule[nozzle] { %subtype = MA1 }
 		}
-		@CONFIG[LR89-NA-5]
-		{
-			%LinkB9PSModule[nozzle] { %subtype = MA3 }
-		}
 		@CONFIG[LR89-NA-6]
 		{
 			%LinkB9PSModule[nozzle] { %subtype = MA3 }


### PR DESCRIPTION
The LR89-NA-5 had a separate turbopump, but shared a gas generator. This means that they still shared a single central exhaust pipe, and the turbopumps were centered in the Atlas skirt instead.
Source: [https://www.enginehistory.org/Rockets/RPE05/RPE05.shtml](url)
![MA-5T](https://github.com/user-attachments/assets/a1893355-f1e4-4da3-8d08-f521bd090ca6)