### PR TITLE
Make pioneer vernier physicsless

### DIFF
--- a/GameData/ROEngines/PartConfigs/PioneerVernier.cfg
+++ b/GameData/ROEngines/PartConfigs/PioneerVernier.cfg
@@ -61,6 +61,7 @@ PART
 	crashTolerance = 10
 	breakingForce = 10000
 	breakingTorque = 10000
+	PhysicsSignificance = 1	//since this is below 1 kg, and apparently has a buggy CoM anyway, just make it physicsless
 	stagingIcon = SOLID_BOOSTER
 	
 	skinTempTag = Steel


### PR DESCRIPTION
Since the pioneer vernier is extremely small (less than 1 kg) and apparently has a weird CoM placement, just make it physicless
resolves https://github.com/KSP-RO/ROEngines/issues/258
resolves https://github.com/KSP-RO/ROEngines/issues/257