### PR TITLE
Add Castor 4A

### DIFF
--- a/GameData/ROEngines/PartConfigs/Castor4_BDB.cfg
+++ b/GameData/ROEngines/PartConfigs/Castor4_BDB.cfg
@@ -130,3 +130,11 @@ PART
 		}
 	}
 }
+
+// The -4A has the same casing as the -4, but a slightly bigger nozzle.
++PART[ROE-Castor4]
+{
+	@name = ROE-Castor4A
+	@engineType = Castor-4A
+	@tags = castor, castor-4a, 4a, iva, castor-iva, delta, atlas, booster, radial, solid, srb, castor4a
+}

--- a/GameData/ROEngines/PatchManager/ActiveMMPatches/Castor-4A.cfg
+++ b/GameData/ROEngines/PatchManager/ActiveMMPatches/Castor-4A.cfg
@@ -1,0 +1,1 @@
+!PART:HAS[~name[ROE-*]&#engineType[Castor-4A]&#category[Engine]]:BEFORE[zzzTagCleanup] {}

--- a/GameData/ROEngines/PatchManager/ROE-PatchManager.cfg
+++ b/GameData/ROEngines/PatchManager/ROE-PatchManager.cfg
@@ -235,6 +235,15 @@ PatchManager
 PatchManager
 {
  modName = ROEngines
+ srcPath = ROEngines/PatchManager/PluginData/Castor-4A.cfg
+ patchName = Castor-4A
+ shortDescr = Castor-4A
+ longDescr = Removes the duplicated Castor-4A engines from other mods.
+ installedWithMod = True
+}
+PatchManager
+{
+ modName = ROEngines
  srcPath = ROEngines/PatchManager/PluginData/Castor-4AXL.cfg
  patchName = Castor-4AXL
  shortDescr = Castor-4AXL

--- a/GameData/ROEngines/RealPlume/Castor4_BDB_RealPlume.cfg
+++ b/GameData/ROEngines/RealPlume/Castor4_BDB_RealPlume.cfg
@@ -1,4 +1,4 @@
-@PART[ROE-Castor4|ROE-Castor4AXL]:BEFORE[RealPlume]
+@PART[ROE-Castor4|ROE-Castor4A|ROE-Castor4AXL]:BEFORE[RealPlume]
 {
 	PLUME
 	{

--- a/GameData/ROEngines/Waterfall/SRM/EarlyCastors.cfg
+++ b/GameData/ROEngines/Waterfall/SRM/EarlyCastors.cfg
@@ -37,7 +37,7 @@
         glow = ro-srm
     }
 }
-@PART[ROE-Castor4|ROE-Castor4AXL]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+@PART[ROE-Castor4|ROE-Castor4A|ROE-Castor4AXL]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
 {
     ROWaterfall
     {


### PR DESCRIPTION
It has the same casing as the Castor 4, but it has a slightly larger nozzle. I doubt the difference is noticable in-game, or that the nozzle on the model is exactly accurate anyway, so just use the Castor 4 model.